### PR TITLE
Add the PREPARED_STATEMENTS environment variable and set it to its default value

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -15,6 +15,7 @@ data:
   DB_NAME: {{ .Values.postgresql.auth.database }}
   DB_POOL: {{ include "mastodon.maxDbPool" . }}
   DB_USER: {{ .Values.postgresql.auth.username }}
+  PREPARED_STATEMENTS: {{ .Values.mastodon.preparedStatements | quote }}
   DEFAULT_LOCALE: {{ .Values.mastodon.locale }}
   {{- if .Values.elasticsearch.enabled }}
   ES_ENABLED: "true"

--- a/values.yaml
+++ b/values.yaml
@@ -202,6 +202,9 @@ mastodon:
       # -- Enable statsd publishing via STATSD_ADDR environment variable
       address: ""
 
+  # Sets the PREPARED_STATEMENTS environment variable: https://docs.joinmastodon.org/admin/config/#prepared_statements
+  preparedStatements: true
+
 ingress:
   enabled: true
   annotations:


### PR DESCRIPTION
Being able to control it can be useful in situations where prepared statements don't work as expected. Once such case can be pgbouncer as provided by DigitalOcean for connection pooling.