### PR TITLE
create initial user with the proper role

### DIFF
--- a/templates/job-create-admin.yaml
+++ b/templates/job-create-admin.yaml
@@ -55,7 +55,7 @@ spec:
             - {{ .Values.mastodon.createAdmin.email }}
             - --confirmed
             - --role
-            - admin
+            - Owner
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env


### PR DESCRIPTION
The role of the initial user should be "Owner" not "admin" (or even "**A**dmin").  This was merged with the original repo in [this PR](https://github.com/mastodon/mastodon/pull/19827) - but seemingly this new repo was created before that.