### PR TITLE
feat(helm-chart): add values for various Puma related settings

### DIFF
--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -74,6 +74,22 @@ spec:
                   key: redis-password
             - name: "PORT"
               value: {{ .Values.mastodon.web.port | quote }}
+            {{- if .Values.mastodon.web.minThreads }}
+            - name: "MIN_THREADS"
+              value: {{ .Values.mastodon.web.minThreads | quote }}
+            {{- end }}
+            {{- if .Values.mastodon.web.maxThreads }}
+            - name: "MAX_THREADS"
+              value: {{ .Values.mastodon.web.maxThreads | quote }}
+            {{- end }}
+            {{- if .Values.mastodon.web.workers }}
+            - name: "WEB_CONCURRENCY"
+              value: {{ .Values.mastodon.web.workers | quote }}
+            {{- end }}
+            {{- if .Values.mastodon.web.persistentTimeout }}
+            - name: "PERSISTENT_TIMEOUT"
+              value: {{ .Values.mastodon.web.persistentTimeout | quote }}
+            {{- end }}
             {{- if (and .Values.mastodon.s3.enabled .Values.mastodon.s3.existingSecret) }}
             - name: "AWS_SECRET_ACCESS_KEY"
               valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -187,6 +187,12 @@ mastodon:
     # requests:
     #   cpu: 250m
     #   memory: 768Mi
+    # -- Puma-specific options. Below values are based on default behavior in
+    # config/puma.rb when no custom values are provided.
+    minThreads: "5"
+    maxThreads: "5"
+    workers: "2"
+    persistentTimeout: "20"
 
   metrics:
     statsd:


### PR DESCRIPTION
_Port of [#21053](https://github.com/mastodon/mastodon/pull/21053) from [mastodon/mastodon](https://github.com/mastodon/mastodon) repository._

---

The `mastodon.web.minThreads` value won't work until [#21048](https://github.com/mastodon/mastodon/pull/21048) is merged.