### PR TITLE
Patching minor bug in `configmap-env.yaml`

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 4.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -25,7 +25,7 @@ data:
   {{- with .Values.mastodon.web_domain }}
   WEB_DOMAIN: {{ . }}
   {{- end }}
-  {{- with .Values.mastodon.singleUserMode }}
+  {{- if .Values.mastodon.singleUserMode }}
   SINGLE_USER_MODE: "true"
   {{- end }}
   {{- with .Values.mastodon.authorizedFetch }}
@@ -51,7 +51,7 @@ data:
   S3_REGION: {{ . }}
   {{- end }}
   {{- with .Values.mastodon.s3.alias_host }}
-  S3_ALIAS_HOST: {{ .Values.mastodon.s3.alias_host}}
+  S3_ALIAS_HOST: {{ . }}
   {{- end }}
   {{- end }}
   {{- with .Values.mastodon.smtp.auth_method }}


### PR DESCRIPTION
There is a minor bug in `configmap-env.yaml` which prevents deployment when using an S3 Alias Host, this patch addresses that.

Also included is a minor change to use an `if` statement when not using anything but the truthy value of the configuration item. 

Please let me know if you have any questions and if you would rather I not submit with the chart patch version bump. 