### PR TITLE
Fix alias_host break on bad var reference (#34)

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -51,7 +51,7 @@ data:
   S3_REGION: {{ . }}
   {{- end }}
   {{- with .Values.mastodon.s3.alias_host }}
-  S3_ALIAS_HOST: {{ .Values.mastodon.s3.alias_host}}
+  S3_ALIAS_HOST: {{ . }}
   {{- end }}
   {{- end }}
   {{- with .Values.mastodon.smtp.auth_method }}


### PR DESCRIPTION
Fix the following break when a caching proxy is specified:

```
Error: INSTALLATION FAILED: template: mastodon/templates/deployment-web.yaml:21:12: executing "mastodon/templates/deployment-web.yaml" at <include "mastodon.rollingPodAnnotations" .>: error calling include: template: mastodon/templates/_helpers.tpl:60:30: executing "mastodon.rollingPodAnnotations" at <include (print $.Template.BasePath "/configmap-env.yaml") .>: error calling include: template: mastodon/templates/configmap-env.yaml:54:27: executing "mastodon/templates/configmap-env.yaml" at <.Values.mastodon.s3.alias_host>: can't evaluate field Values in type string
```