### PR TITLE
fix double dereference of `.Values.mastodon.s3.alias_host`

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -51,7 +51,7 @@ data:
   S3_REGION: {{ . }}
   {{- end }}
   {{- with .Values.mastodon.s3.alias_host }}
-  S3_ALIAS_HOST: {{ .Values.mastodon.s3.alias_host}}
+  S3_ALIAS_HOST: {{ . }}
   {{- end }}
   {{- end }}
   {{- with .Values.mastodon.smtp.auth_method }}


### PR DESCRIPTION
Carrying over https://github.com/mastodon/mastodon/pull/21623