### PR TITLE
Fix S3_ALIAS_HOST in configmap

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 4.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -51,7 +51,7 @@ data:
   S3_REGION: {{ . }}
   {{- end }}
   {{- with .Values.mastodon.s3.alias_host }}
-  S3_ALIAS_HOST: {{ .Values.mastodon.s3.alias_host}}
+  S3_ALIAS_HOST: {{ . }}
   {{- end }}
   {{- end }}
   {{- with .Values.mastodon.smtp.auth_method }}


### PR DESCRIPTION
Hey folks,

A simple bugfix here - the way that the s3.aliashost value was added to the configmap was incorrect, resulting in a helm parsing error when actually trying to use this value.

This PR fixes the error :)

D