### PR TITLE
Fix container create error on unauthenticated SMTP

### DIFF
--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -102,6 +102,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "mastodon.smtp.secretName" $context }}
                   key: password
+                  optional: true
             {{- if (and $context.Values.mastodon.s3.enabled $context.Values.mastodon.s3.existingSecret) }}
             - name: "AWS_SECRET_ACCESS_KEY"
               valueFrom:


### PR DESCRIPTION
If you're using an internal SMTP server which doesn't use authentication for services, then the helm chart deploys an unusable sidekiq container;

```console
$ kubectl --namespace mastodon get pods
...
mastodon-sidekiq-all-queues-58c6b4948f-fktj6   0/1     CreateContainerConfigError   0                24s
$ kubectl --namespace get events | grep sidekiq
...
32s       Warning   Failed                   pod/mastodon-sidekiq-all-queues-58c6b4948f-fktj6    Error: couldn't find key password in Secret mastodon/mastodon-smtp
```