### PR TITLE
Use unique annotation key for smtp secret checksum (#48)

### DIFF
--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -31,7 +31,7 @@ spec:
         {{- end }}
         # roll the pods to pick up any db migrations or other changes
         {{- include "mastodon.rollingPodAnnotations" $context | nindent 8 }}
-        checksum/config-secrets: {{ include ( print $.Template.BasePath "/secret-smtp.yaml" ) $context | sha256sum | quote }}
+        checksum/config-secrets-smtp: {{ include ( print $.Template.BasePath "/secret-smtp.yaml" ) $context | sha256sum | quote }}
       labels:
         {{- include "mastodon.selectorLabels" $context | nindent 8 }}
         app.kubernetes.io/component: sidekiq-{{ .name }}


### PR DESCRIPTION
Use an unique annotation key for the smtp secret checksum, fixing the conflict mentioned in #48.