### PR TITLE
Update image repository to GHCR

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: tootsuite/mastodon
-  # https://hub.docker.com/r/tootsuite/mastodon/tags
+  repository: ghcr.io/mastodon/mastodon
+  # https://github.com/mastodon/mastodon/pkgs/container/mastodon
   #
   # alternatively, use `latest` for the latest release or `edge` for the image
   # built from the most recent commit


### PR DESCRIPTION
The Docker Hub `tootsuite/mastodon` image is deprecated and will soon no longer be available, due to Docker deleting every organisation on a free plan.

Images with the latest tags for all supported releases (3.5, 4.0, 4.1) have been synced here, and new versions will be published on this repo.