### PR TITLE
add workflow and documentation for OCI release

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,0 +1,30 @@
+# Publish chart as OCI image to GitHub registry. Version is automatically gathered from the tag name.
+# For this workflow to work, GITHUB_TOKEN needs to be configured with write permissions.
+# Additionally, the repository must be granted access in the package settings.
+
+name: Publish chart
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  release:
+    name: Publish chart to OCI registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Helm login
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+          helm registry login ghcr.io \
+            --username "$GITHUB_REPOSITORY_OWNER" \
+            --password-stdin
+      - name: Helm package
+        run: |
+          helm package . -u --version "${GITHUB_REF_NAME#v}"
+      - name: Helm push
+        run: |
+          helm push \
+          "mastodon-${GITHUB_REF_NAME#v}.tgz" \
+          "oci://ghcr.io/$GITHUB_REPOSITORY_OWNER/charts"

--- a/Chart.lock
+++ b/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: redis
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 16.13.2
-digest: sha256:17ea58a3264aa22faff18215c4269f47dabae956d0df273c684972f356416193
-generated: "2022-08-08T21:44:18.0195364+02:00"
+digest: sha256:8be2c8069d65f295d0079bdda67c45691370f7bef73393c2e80eedbdd748b9af
+generated: "2023-03-16T11:10:48.909118173+01:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,10 +12,10 @@ description: Mastodon is a free, open-source social network server based on Acti
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+# Chart version is set to 0.0.0 in the source tree. The release pipeline replaces this with the version
+# being released in build time.
+# Please refer to git tags and/or GitHub releases to check out the latest version.
+version: 0.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ Kubernetes cluster.  The basic usage is:
 
 This chart is tested with k8s 1.21+ and helm 3.6.0+.
 
+# Installation
+
+This chart is [released as an OCI image](https://helm.sh/docs/topics/registries/) to `ghcr.io/mastodon/chart`. You can install it without the need to add any repository to your helm installation using:
+
+```shell
+helm install mastodon oci://ghcr.io/mastodon/charts/mastodon --values your-values-file.yaml
+```
+
+You can also add it as a dependency to another chart in your Chart.yaml:
+
+```yaml
+dependencies:
+  - name: mastodon
+    version: 4.0.0
+    repository: oci://ghcr.io/mastodon/charts
+```
+
 # Configuration
 
 The variables that _must_ be configured are:


### PR DESCRIPTION
This PR proposes an alternative, and allegedly simpler and more modern approach to releasing this chart for easier consumption by users.

## The problem

So far, the mastodon chart is not packaged in any way, making its use cumbersome. In my personal case, I need to have a hacky shell script downloading the latest `.tar.gz` from this repo and copying it to a `charts/` directory by hand.

## Alternative solutions

[chart-releaser](https://github.com/helm/chart-releaser-action) has been the de-facto standard for releasing charts for a long time. However, it has, in my view, several limitations:
- It needs to (or is recommended to) run on every push to `main`. This makes hard to control when features are released.
- It enforces the version specified in `Chart.version`. This means contributors need to bump this themselves, adding friction.
- It (ab)uses github pages, which I personally don't find very clean.

## This approach

For a long time, helm itself has supported [publishing charts to OCI registires](https://helm.sh/docs/topics/registries/). I think this feature is awesome but for some reason it has not been widely adopted by the community yet. This PR implements that very same approach, which is simple and straightforward to implement, use, and understand.

### How it works

First the `version` filed in `Chart.yaml` is set to `0.0.0`. Maintainers or contributors do not need to touch this field anymore (but `.Chart.Version` will keep working in templates). Releases are triggered by creating a release in github, as it is customary with Github projects. The version of the chat is trivially derived from the tag that accompanies that version (e.g., release `v4.0.0` will produce a chart version `4.0.0`). This number is used by the `helm package` command to produce a chart package which is later pushed to `ghcr.io` as if it were a docker image.

Users can install the chart or add it as a dependency as normal, using `oci://ghcr.io/mastodon/charts/mastodon` as the chart url.

## Other comments

I understand this is pretty much a maintainer decision, so It's okay if you don't like it. I opted for jumping directly with a PR because it took me very little time to adapt this workflow from other charts I manage, and because I think it's useful to "let the code do the talking". Looking forward to hear your thoughts!

---

Closes #27