### PR TITLE
Fix a deployment error due to duplicate annotation on sidekiq

### DIFF
--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -31,7 +31,7 @@ spec:
         {{- end }}
         # roll the pods to pick up any db migrations or other changes
         {{- include "mastodon.rollingPodAnnotations" $context | nindent 8 }}
-        checksum/config-secrets: {{ include ( print $.Template.BasePath "/secret-smtp.yaml" ) $context | sha256sum | quote }}
+        checksum/config-smtp-secrets: {{ include ( print $.Template.BasePath "/secret-smtp.yaml" ) $context | sha256sum | quote }}
       labels:
         {{- include "mastodon.selectorLabels" $context | nindent 8 }}
         app.kubernetes.io/component: sidekiq-{{ .name }}


### PR DESCRIPTION
The `mastodon.rollingPodAnnotations` template already creates an annotation named checksum/config-secrets, resulting in a duplicate value which will cause all Helm installs/upgrades to fail if any post-render task attempts to run