### PR TITLE
Fix duplicate annotation on sidekiq preventing flux install

### DIFF
--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -31,7 +31,7 @@ spec:
         {{- end }}
         # roll the pods to pick up any db migrations or other changes
         {{- include "mastodon.rollingPodAnnotations" $context | nindent 8 }}
-        checksum/config-secrets: {{ include ( print $.Template.BasePath "/secret-smtp.yaml" ) $context | sha256sum | quote }}
+        checksum/config-smtp-secrets: {{ include ( print $.Template.BasePath "/secret-smtp.yaml" ) $context | sha256sum | quote }}
       labels:
         {{- include "mastodon.selectorLabels" $context | nindent 8 }}
         app.kubernetes.io/component: sidekiq-{{ .name }}


### PR DESCRIPTION
Hi folks,

This PR simple fixes https://github.com/mastodon/chart/issues/48, resolving the duplicate annotation which will cause the chart to fail to install when using fluxcd (_and presumably others, although cli `helm` seems to ignore duplicates_)

Cheers! :)
D