### PR TITLE
Helm dep should use install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a [Helm](https://helm.sh/) chart for installing Mastodon into a
 Kubernetes cluster.  The basic usage is:
 
 1. edit `values.yaml` or create a separate yaml file for custom values
-1. `helm dep update`
+1. `helm dep install`
 1. `helm install --namespace mastodon --create-namespace my-mastodon ./ -f path/to/additional/values.yaml`
 
 This chart is tested with k8s 1.21+ and helm 3.6.0+.


### PR DESCRIPTION
The current instructions instruct to always update dependencies to the latest in range instead of installing the currently locked version. This ensures you're using the tested locked versions.