### PR TITLE
Allow dual-stack operation on clusters so equipped.

### DIFF
--- a/templates/service-streaming.yaml
+++ b/templates/service-streaming.yaml
@@ -11,6 +11,7 @@ spec:
       targetPort: streaming
       protocol: TCP
       name: streaming
+  ipFamilyPolicy: PreferDualStack
   selector:
     {{- include "mastodon.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: streaming

--- a/templates/service-web.yaml
+++ b/templates/service-web.yaml
@@ -11,6 +11,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  ipFamilyPolicy: PreferDualStack
   selector:
     {{- include "mastodon.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: web


### PR DESCRIPTION
At the moment, the Helm chart does not allow clean installation on Kubernetes clusters running in dual-stack mode.

For example, on my own k3s cluster, the Mastodon services are assigned only IPv6 addresses and use only IPv6 endpoints, which fails both IPv4 clients and causes problems with the Mastodon pods which, at the moment, only bind to IPv4 addresses on a dual-stack cluster. (The related issue to fix that problem is here: https://github.com/mastodon/mastodon/issues/25371 ; at the moment I had to bypass it by hacking BIND definitions into this Helm chart, but a proper fix would obviously be preferable.)

This PR remedies the problem by setting _ipFamilyPolicy: PreferDualStack_ on the services the chart creates, which makes dual-stack clusters operate correctly and should have no side-effects on single-stack clusters.