### PR TITLE
change configmap-env helm hook weight to be installed before job-db-migrate

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "mastodon.fullname" . }}-env
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-3"
 data:
   {{- if .Values.postgresql.enabled }}
   DB_HOST: {{ template "mastodon.postgresql.fullname" . }}


### PR DESCRIPTION
This is to solve #73 where the db-migrate job tries to run before the configmap it needs is in place. This change will just install the configmap before the db-migrate job.