### PR TITLE
fix inheritance of sidekiq securityContext

### DIFF
--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -81,8 +81,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ $context.Chart.Name }}
+          {{- with $context.Values.mastodon.sidekiq.securityContext | default $context.Values.securityContext }}
           securityContext:
-            {{- toYaml $context.Values.mastodon.sidekiq.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ coalesce (dig "image" "repository" false .) $context.Values.image.repository }}:{{ coalesce (dig "image" "tag" false .) $context.Values.image.tag $context.Chart.AppVersion }}"
           imagePullPolicy: {{ $context.Values.image.pullPolicy }}
           command:


### PR DESCRIPTION
`values.yaml` says:

```
  sidekiq:
    # -- Pod security context for all Sidekiq Pods, overwrites .Values.podSecurityContext
    podSecurityContext: {}
    # -- (Sidekiq Container) Security Context for all Pods, overwrites .Values.securityContext
    securityContext: {}
```

However, this was not true before this PR: Only `sidekiq.securityContext` was considered, defaulting to an empty security context if it was not set.