### PR TITLE
Change default Secret name to not rely on Bitnami

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -96,7 +96,7 @@ Get the mastodon secret.
 {{- if .Values.mastodon.secrets.existingSecret }}
     {{- printf "%s" (tpl .Values.mastodon.secrets.existingSecret $) -}}
 {{- else -}}
-    {{- printf "%s" (include "common.names.fullname" .) -}}
+    {{- printf "%s" (include "mastodon.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -107,7 +107,7 @@ Get the smtp secret.
 {{- if .Values.mastodon.smtp.existingSecret }}
     {{- printf "%s" (tpl .Values.mastodon.smtp.existingSecret $) -}}
 {{- else -}}
-    {{- printf "%s-smtp" (include "common.names.fullname" .) -}}
+    {{- printf "%s-smtp" (include "mastodon.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -120,7 +120,7 @@ Get the postgresql secret.
 {{- else if .Values.postgresql.enabled -}}
     {{- printf "%s-postgresql" (tpl .Release.Name $) -}}
 {{- else -}}
-    {{- printf "%s" (include "common.names.fullname" .) -}}
+    {{- printf "%s" (include "mastodon.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/secret-smtp.yaml
+++ b/templates/secret-smtp.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-smtp" (include "common.names.fullname" .) }}
+  name: {{ printf "%s-smtp" (include "mastodon.fullname" .) }}
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
Replace common.names.fullname in the default Secret name template with mastodon.fullname

This removes all Bitnami dependencies for installs not using the Bitnami PostgreSQL, Redis, and Elasticsearch. Those charts populate the common.names.fullname template value. Installs not using these charts will receive an error. Instead, use mastodon.fullname like in secrets.yaml.

Fix mastodon/chart#60
Fix mastodon/chart#65