### PR TITLE
Update dependencies

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 19.13.0
 - name: postgresql
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-  version: 11.1.3
+  version: 11.9.13
 - name: redis
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 18.1.2
-digest: sha256:9458ab5273614db5f654155a9e43b58e7ee5d2c89c9b7b8ae1d4da1bf930378f
-generated: "2023-10-04T16:03:10.461168627-05:00"
+digest: sha256:0dd7ac1e5aee1c0ff36470013f2a533f98be4f77c1a213cefebb706df4d03117
+generated: "2023-10-06T18:26:33.216759824-05:00"

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: elasticsearch
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-  version: 19.0.1
+  version: 19.13.0
 - name: postgresql
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 11.1.3
 - name: redis
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-  version: 16.13.2
-digest: sha256:17ea58a3264aa22faff18215c4269f47dabae956d0df273c684972f356416193
-generated: "2022-08-08T21:44:18.0195364+02:00"
+  version: 18.1.2
+digest: sha256:9458ab5273614db5f654155a9e43b58e7ee5d2c89c9b7b8ae1d4da1bf930378f
+generated: "2023-10-04T16:03:10.461168627-05:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: elasticsearch.enabled
   - name: postgresql
-    version: 11.1.3
+    version: 11.9.13
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: redis

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -24,7 +24,7 @@ appVersion: v4.0.2
 
 dependencies:
   - name: elasticsearch
-    version: 19.11.3
+    version: 19.13.0
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: elasticsearch.enabled
   - name: postgresql
@@ -32,6 +32,6 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: redis
-    version: 16.13.2
+    version: 18.1.2
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: redis.enabled

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -24,7 +24,7 @@ appVersion: v4.0.2
 
 dependencies:
   - name: elasticsearch
-    version: 19.0.1
+    version: 19.11.3
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: elasticsearch.enabled
   - name: postgresql


### PR DESCRIPTION
Upgrade all three of our dependency charts. I upgraded major version for the redis chart because we specify the major version of the app to pull, while our elasticsearch chart is already on the latest major version. I limited myself to a minor-patch upgrade for postgresql for three reasons:

1. Each major increment on the chart increments the underlying postgres major version in the defaults, and we don't assert a version ourselves. I don't want to change that unilaterally.
2. Last I looked, pgAdmin isn't yet compatible with postgres 15, so we'd probably want to stay one major version behind to avoid implicitly locking deployments out of a popular monitoring app.
3. I use an external postgres cluster and don't have an easy way to test compatibility on that upgrade.

This PR addresses #90, #57, and #23. I believe it also addresses #25, but would like confirmation from someone running on an ARM cluster.