### PR TITLE
Add values to inject trusted certs into streaming

### DIFF
--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -37,6 +37,16 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.mastodon.streaming.extraCerts }}
+      {{- $name := .name | default "extra-certs" }}
+      volumes:
+        - name: {{ $name }}
+          secret:
+            secretName: {{ .existingSecret }}
+            items:
+            - key: ca.crt
+              path: trusted-ca.crt
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-streaming
           {{- with (default .Values.securityContext .Values.mastodon.streaming.securityContext) }}
@@ -48,10 +58,27 @@ spec:
           command:
             - node
             - ./streaming
+          {{- with .Values.mastodon.streaming.extraCerts }}
+          volumeMounts:
+          - name: {{ $name }}
+            mountPath: "/usr/local/share/ca-certificates"
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env
           env:
+            {{- with .Values.mastodon.streaming.extraCerts }}
+            - name: "NODE_EXTRA_CA_CERTS"
+              value: "/usr/local/share/ca-certificates/trusted-ca.crt"
+            {{- with .sslMode }}
+            - name: "DB_SSLMODE"
+              value: {{ . }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.postgresql.postgresqlReplicaHostname }}
+            - name: "DB_HOST"
+              value: {{ . }}
+            {{- end }}
             - name: "DB_PASS"
               valueFrom:
                 secretKeyRef:

--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -59,6 +59,7 @@ spec:
             - node
             - ./streaming
           {{- with .Values.mastodon.streaming.extraCerts }}
+          {{- $name := .name | default "extra-certs" }}
           volumeMounts:
           - name: {{ $name }}
             mountPath: "/usr/local/share/ca-certificates"

--- a/values.yaml
+++ b/values.yaml
@@ -213,6 +213,14 @@ mastodon:
     # requests:
     #   cpu: 250m
     #   memory: 128Mi
+    # -- Self-signed certificate(s) the (Node.js) needs to trust to connect to e.g. the database
+    extraCerts: {}
+    # -- Secret containing a key "ca.crt" holding one or more root certificates in PEM format
+    #  existingSecret:
+    # -- Optional volume name for mounting the .crt file, defaults to "extra-certs"
+    #  name:
+    # -- Optional sslMode setting. See nodejs's SSL_MODE. Consider "no-verify"
+    #  sslMode:
   web:
     port: 3000
     # -- Number of Web Pods running


### PR DESCRIPTION
This PR addresses #86 

Node.js appears to be more picky about self-signed certificates than rails. That said, it accepts a (singular) file containing one or more root certificates that should be trusted alongside the system's CAs. This changeset declares a short stanza, `mastodon.streaming.extraCerts`, empty by default, which can pull a .crt file from an existing secret. It then mounts that file as a projected volume and passes the filepath to node via an env var. The stanza also allows users to set the TLS "mode" (read: validation strictness) that Node will use. In my testing, it seemed that `no-verify` may be necessary for some root certs, but can be avoided often enough that it seems wise not to use it as a default value.

Lastly, the stanza allows you to pick a custom name for the projected volume name, in case of compatibility issues.

I want to acknowledge @SISheogorath both for setting me on the TLS path and for providing a working example from their server. While I didn't happen to see the example until I climbed out of my rabbit hole with a similar solution of my own, it was very encouraging to know I wasn't hacking something overly clever together, and saved me a lot of time confirming this was an appropriate solution.