### PR TITLE
Add S3_OVERRIDE_PATH_STYLE to mastodon-env ConfigMap

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -60,6 +60,9 @@ data:
   {{- with .Values.mastodon.s3.alias_host }}
   S3_ALIAS_HOST: {{ . }}
   {{- end }}
+  {{- with .Values.mastodon.s3.override_path_style }}
+  S3_OVERRIDE_PATH_STYLE: "{{ . }}"
+  {{- end }}
   {{- end }}
   {{- with .Values.mastodon.smtp.auth_method }}
   SMTP_AUTH_METHOD: {{ . }}


### PR DESCRIPTION
This PR addresses #93 by adding a matching boolean key to the `mastodon.s3` stanza.