### PR TITLE
Add job template to deploy search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 6.1.0
+
+- Added a new job to re/build elasticsearch indices as a post-upgrade hook:
+```yaml
+mastodon:
+  hooks:
+    deploySearch:
+```
+
 # 6.0.3
 
 - Updated the Mastodon version to v4.3.5

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.0.3
+version: 6.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/job-deploy-search.yaml
+++ b/templates/job-deploy-search.yaml
@@ -62,6 +62,10 @@ spec:
             {{- if .Values.mastodon.deploySearch.resetChewy }}
             - '--reset-chewy'
             {{- end }}
+            {{- with .Values.mastodon.deploySearch.batchSize }}
+            - '--batch-size'
+            - {{ . | quote }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "oliphaunt.fullname" . }}-mastodon-env

--- a/templates/job-deploy-search.yaml
+++ b/templates/job-deploy-search.yaml
@@ -2,9 +2,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "oliphaunt.fullname" . }}-deploy-search
+  name: {{ include "mastodon.fullname" . }}-deploy-search
   labels:
-    {{- include "oliphaunt.labels" . | nindent 4 }}
+    {{- include "mastodon.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -13,7 +13,7 @@ spec:
   suspend: false
   template:
     metadata:
-      name: {{ include "oliphaunt.fullname" . }}-deploy-search
+      name: {{ include "mastodon.fullname" . }}-deploy-search
       {{- with .Values.jobAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -38,13 +38,13 @@ spec:
       volumes:
         - name: assets
           persistentVolumeClaim:
-            claimName: {{ template "oliphaunt.fullname" . }}-assets
+            claimName: {{ template "mastodon.fullname" . }}-assets
         - name: system
           persistentVolumeClaim:
-            claimName: {{ template "oliphaunt.fullname" . }}-system
+            claimName: {{ template "mastodon.fullname" . }}-system
       {{- end }}
       containers:
-        - name: {{ include "oliphaunt.fullname" . }}-deploy-search
+        - name: {{ include "mastodon.fullname" . }}-deploy-search
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
@@ -68,7 +68,7 @@ spec:
             {{- end }}
           envFrom:
             - configMapRef:
-                name: {{ include "oliphaunt.fullname" . }}-mastodon-env
+                name: {{ include "mastodon.fullname" . }}-env
             - secretRef:
                 name: {{ template "mastodon.secretName" $ }}
           env:

--- a/templates/job-deploy-search.yaml
+++ b/templates/job-deploy-search.yaml
@@ -1,0 +1,90 @@
+{{- if and .Values.mastodon.deploySearch.enabled .Values.elasticsearch.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "oliphaunt.fullname" . }}-deploy-search
+  labels:
+    {{- include "oliphaunt.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-2"
+spec:
+  suspend: false
+  template:
+    metadata:
+      name: {{ include "oliphaunt.fullname" . }}-deploy-search
+      {{- with .Values.jobAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: Never
+      {{- if (not .Values.mastodon.s3.enabled) }}
+      # ensure we run on the same node as the other rails components; only
+      # required when using PVCs that are ReadWriteOnce
+      {{- if or (eq "ReadWriteOnce" .Values.mastodon.persistence.assets.accessMode) (eq "ReadWriteOnce" .Values.persistence.system.accessMode) }}
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/part-of
+                  operator: In
+                  values:
+                    - rails
+            topologyKey: kubernetes.io/hostname
+      {{- end }}
+      volumes:
+        - name: assets
+          persistentVolumeClaim:
+            claimName: {{ template "oliphaunt.fullname" . }}-assets
+        - name: system
+          persistentVolumeClaim:
+            claimName: {{ template "oliphaunt.fullname" . }}-system
+      {{- end }}
+      containers:
+        - name: {{ include "oliphaunt.fullname" . }}-deploy-search
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            requests:
+              cpu: 700m
+              memory: 768Mi
+          command:
+            - bin/tootctl
+            - search
+            - deploy
+            {{- with .Values.mastodon.deploySearch.concurrency }}
+            - '--concurrency'
+            - {{ . | quote }}
+            {{- end }}
+            {{- if .Values.mastodon.deploySearch.resetChewy }}
+            - '--reset-chewy'
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "oliphaunt.fullname" . }}-mastodon-env
+            - secretRef:
+                name: {{ template "mastodon.secretName" $ }}
+          env:
+            - name: "DB_PASS"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mastodon.postgresql.secretName" . }}
+                  key: password
+            - name: "REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mastodon.redis.secretName" . }}
+                  key: redis-password
+            - name: "PORT"
+              value: {{ .Values.mastodon.web.port | quote }}
+          {{- if (not .Values.mastodon.s3.enabled) }}
+          volumeMounts:
+            - name: assets
+              mountPath: /opt/mastodon/public/assets
+            - name: system
+              mountPath: /opt/mastodon/public/system
+          {{- end }}
+{{- end }}

--- a/templates/job-deploy-search.yaml
+++ b/templates/job-deploy-search.yaml
@@ -66,6 +66,13 @@ spec:
             - '--batch-size'
             - {{ . | quote }}
             {{- end }}
+            {{- with .Values.mastodon.hooks.deploySearch.only }}
+              {{- if not (has . (list "instances" "accounts" "tags" "statuses" "public_statuses")) -}}
+                {{ fail "mastodon.hooks.deploySearch.only: Value must be one of the following words: instances, accounts, tags, statuses, public_statuses"}}
+              {{- end }}
+            - '--only'
+            - {{ . | quote }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env

--- a/templates/job-deploy-search.yaml
+++ b/templates/job-deploy-search.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mastodon.deploySearch.enabled .Values.elasticsearch.enabled -}}
+{{- if and .Values.mastodon.hooks.deploySearch.enabled .Values.elasticsearch.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -55,14 +55,14 @@ spec:
             - bin/tootctl
             - search
             - deploy
-            {{- with .Values.mastodon.deploySearch.concurrency }}
+            {{- with .Values.mastodon.hooks.deploySearch.concurrency }}
             - '--concurrency'
             - {{ . | quote }}
             {{- end }}
-            {{- if .Values.mastodon.deploySearch.resetChewy }}
+            {{- if .Values.mastodon.hooks.deploySearch.resetChewy }}
             - '--reset-chewy'
             {{- end }}
-            {{- with .Values.mastodon.deploySearch.batchSize }}
+            {{- with .Values.mastodon.hooks.deploySearch.batchSize }}
             - '--batch-size'
             - {{ . | quote }}
             {{- end }}

--- a/templates/job-deploy-search.yaml
+++ b/templates/job-deploy-search.yaml
@@ -47,10 +47,10 @@ spec:
         - name: {{ include "mastodon.fullname" . }}-deploy-search
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.mastodon.hooks.deploySearch.resources }}
           resources:
-            requests:
-              cpu: 700m
-              memory: 768Mi
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - bin/tootctl
             - search

--- a/templates/job-deploy-search.yaml
+++ b/templates/job-deploy-search.yaml
@@ -47,7 +47,8 @@ spec:
         - name: {{ include "mastodon.fullname" . }}-deploy-search
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.mastodon.hooks.deploySearch.resources }}
+          {{- with .Values.mastodon.hooks.deploySearch }}
+          {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -55,24 +56,25 @@ spec:
             - bin/tootctl
             - search
             - deploy
-            {{- with .Values.mastodon.hooks.deploySearch.concurrency }}
+            {{- with .concurrency }}
             - '--concurrency'
             - {{ . | quote }}
             {{- end }}
-            {{- if .Values.mastodon.hooks.deploySearch.resetChewy }}
+            {{- if .resetChewy }}
             - '--reset-chewy'
             {{- end }}
-            {{- with .Values.mastodon.hooks.deploySearch.batchSize }}
+            {{- with .batchSize }}
             - '--batch-size'
             - {{ . | quote }}
             {{- end }}
-            {{- with .Values.mastodon.hooks.deploySearch.only }}
+            {{- with .only }}
               {{- if not (has . (list "instances" "accounts" "tags" "statuses" "public_statuses")) -}}
                 {{ fail "mastodon.hooks.deploySearch.only: Value must be one of the following words: instances, accounts, tags, statuses, public_statuses"}}
               {{- end }}
             - '--only'
             - {{ . | quote }}
             {{- end }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env

--- a/values.yaml
+++ b/values.yaml
@@ -49,7 +49,7 @@ mastodon:
     # with timing hooks to ensure the job runs immediately after install/upgrade
     # and will be restarted if another, corrective upgrade is triggered.
     # Please check the tootctl documentation and upgrade notes to pick values.
-    # 
+    #
     # NOTE: The resource stanza set below is intentionally very conservative.
     # Consider assigning a liberal chunk of your cluster's typical headroom.
     deploySearch:

--- a/values.yaml
+++ b/values.yaml
@@ -40,6 +40,11 @@ mastodon:
       concurrency: 5
       resetChewy: true
       only: "" # one index name. Possible values: instances, accounts, tags, statuses, public_statuses
+      resources:
+        requests:
+          cpu: 700m
+          memory: 768Mi
+
     # Upload website assets to S3 before deploying using rclone.
     # Whenever there is an update to Mastodon, sometimes there are assets files
     # that are renamed. As the pods are getting redeployed, and old/new pods are

--- a/values.yaml
+++ b/values.yaml
@@ -39,6 +39,7 @@ mastodon:
       enabled: false
       concurrency: 5
       resetChewy: true
+      only: "" # one index name. Possible values: instances, accounts, tags, statuses, public_statuses
     # Upload website assets to S3 before deploying using rclone.
     # Whenever there is an update to Mastodon, sometimes there are assets files
     # that are renamed. As the pods are getting redeployed, and old/new pods are

--- a/values.yaml
+++ b/values.yaml
@@ -35,11 +35,29 @@ mastodon:
     # Whether to perform DB migrations on `helm upgrade`.
     dbMigrate:
       enabled: true
+
+    # WARNING: deploySearch is potentially a very expensive job!
+    # Only enable this once at a time, when you deploy elasticsearch or when
+    # the upgrade notes for a new mastodon version request rebuilding search.
+    # Recommended use is via `-f mastodon.hooks.deploySearch.enabled=true`
+    # to ensure the job is only dispatched for a single upgrade when required.
+    # This job may take days to run on very large instances. Even small
+    # instances may take long enough to trigger helm's completion timeout, so
+    # DO NOT PANIC if helm complains; simply verify the job is still running.
+    #
+    # Builds or rebuilds the elasticsearch indices via `tootctl deploy search`
+    # with timing hooks to ensure the job runs immediately after install/upgrade
+    # and will be restarted if another, corrective upgrade is triggered.
+    # Please check the tootctl documentation and upgrade notes to pick values.
+    # 
+    # NOTE: The resource stanza set below is intentionally very conservative.
+    # Consider assigning a liberal chunk of your cluster's typical headroom.
     deploySearch:
       enabled: false
-      concurrency: 5
       resetChewy: true
-      only: "" # one index name. Possible values: instances, accounts, tags, statuses, public_statuses
+      # one index name. Possible values: instances, accounts, tags, statuses, public_statuses
+      only: ""
+      concurrency: 5
       resources: # this accepts any keys in a full container resources stanza.
         requests:
           cpu: 250m

--- a/values.yaml
+++ b/values.yaml
@@ -35,6 +35,10 @@ mastodon:
     # Whether to perform DB migrations on `helm upgrade`.
     dbMigrate:
       enabled: true
+    deploySearch:
+      enabled: false
+      concurrency: 5
+      resetChewy: true
     # Upload website assets to S3 before deploying using rclone.
     # Whenever there is an update to Mastodon, sometimes there are assets files
     # that are renamed. As the pods are getting redeployed, and old/new pods are
@@ -60,10 +64,6 @@ mastodon:
   # Custom labels to add to kubernetes resources
   #labels:
   # -- deploy search to elastsicsearch. Requires .elasticsearch.enabled = true
-  deploySearch:
-    enabled: false
-    concurrency: 5
-    resetChewy: true
   cron:
     # -- run `tootctl media remove` every week
     removeMedia:

--- a/values.yaml
+++ b/values.yaml
@@ -40,10 +40,12 @@ mastodon:
       concurrency: 5
       resetChewy: true
       only: "" # one index name. Possible values: instances, accounts, tags, statuses, public_statuses
-      resources:
+      resources: # this accepts any keys in a full container resources stanza.
         requests:
-          cpu: 700m
-          memory: 768Mi
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          cpu: 500m
 
     # Upload website assets to S3 before deploying using rclone.
     # Whenever there is an update to Mastodon, sometimes there are assets files

--- a/values.yaml
+++ b/values.yaml
@@ -59,6 +59,11 @@ mastodon:
         env: {}
   # Custom labels to add to kubernetes resources
   #labels:
+  # -- deploy search to elastsicsearch. Requires .elasticsearch.enabled = true
+  deploySearch:
+    enabled: false
+    concurrency: 5
+    resetChewy: true
   cron:
     # -- run `tootctl media remove` every week
     removeMedia:


### PR DESCRIPTION
This creates a simple job template to fire off when deploying elasticsearch, e.g. as part of upgrading to 4.2.0 and beyond.