### PR TITLE
Set default Redis replica count to 0

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -281,6 +281,8 @@ redis:
     # you can also specify the name of an existing Secret
     # with a key of redis-password set to the password you want
     # existingSecret: ""
+  replica:
+    replicaCount: 0
 
 # @ignored
 service:


### PR DESCRIPTION
Since the configmap-env sets the `REDIS_HOST` to `namespace-redis-master` if the `redis.host`value is not set (indicating that an existing Redis install is to be used) any replicas will not be used and the Bitnami chart defaults to 3 unused replicas.