### PR TITLE
feat(deployments): make spec.revisionHistoryLimit configurable

### DIFF
--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -22,7 +22,9 @@ spec:
     type: Recreate
   {{- end }}
   replicas: {{ .replicas }}
-  revisionHistoryLimit: 2
+  {{- if (ne (toString $context.Values.mastodon.revisionHistoryLimit) "<nil>") }}
+  revisionHistoryLimit: {{ $context.Values.mastodon.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" $context | nindent 6 }}

--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -10,7 +10,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.mastodon.streaming.replicas }}
-  revisionHistoryLimit: 2
+  {{- if (ne (toString .Values.mastodon.revisionHistoryLimit) "<nil>") }}
+  revisionHistoryLimit: {{ .Values.mastodon.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}

--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -10,7 +10,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.mastodon.web.replicas }}
-  revisionHistoryLimit: 2
+  {{- if (ne (toString .Values.mastodon.revisionHistoryLimit) "<nil>") }}
+  revisionHistoryLimit: {{ .Values.mastodon.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -101,6 +101,11 @@ mastodon:
     # with keys SECRET_KEY_BASE and OTP_SECRET and
     # VAPID_PRIVATE_KEY and VAPID_PUBLIC_KEY
     existingSecret: ""
+
+  # -- The number of old revisions to keep for each Deployment in Kubernetes.
+  #    See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
+  revisionHistoryLimit: 2
+
   sidekiq:
     # -- Pod security context for all Sidekiq Pods, overwrites .Values.podSecurityContext
     podSecurityContext: {}


### PR DESCRIPTION
Allow setting the spec.revisionHistoryLimit value on Deployment resources to a custom value.