### PR TITLE
feat(app): upgrade Mastodon to 4.2.5

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.0
+version: 4.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v4.2.3
+appVersion: v4.2.5
 
 dependencies:
   - name: elasticsearch

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ image:
   # built from the most recent commit
   #
   # tag: latest
-  tag: "v4.2"
+  tag: "v4.2.5"
   # use `Always` when using `latest` tag
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The default `image.tag` value has been changed from `v4.2` to the exact `v4.2.5` version. With the non-exact version tag, patch upgrades on existing installs would be missed unless `image.pullPolicy` has been customized to `Always`.