### PR TITLE
deps: update to latest versions, switch to OCI repo [semver-major]

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -78,6 +78,9 @@ jobs:
           - k3s-channel: v1.21
             helm-version: v3.6.0
 
+    env:
+      HELM_EXPERIMENTAL_OCI: "1"
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -76,7 +76,7 @@ jobs:
           # higher.
           #
           - k3s-channel: v1.21
-            helm-version: v3.6.0
+            helm-version: v3.8.0
 
     env:
       HELM_EXPERIMENTAL_OCI: "1"

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: elasticsearch
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-  version: 19.0.1
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 19.19.2
 - name: postgresql
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-  version: 11.1.3
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 14.2.3
 - name: redis
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-  version: 16.13.2
-digest: sha256:8be2c8069d65f295d0079bdda67c45691370f7bef73393c2e80eedbdd748b9af
-generated: "2024-01-19T13:45:12.079125474+01:00"
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 18.16.1
+digest: sha256:684daaf2067d96e2aa6d93e9d29b7b13fc586f6ae929342e5e9c7c169b1c0748
+generated: "2024-02-23T15:14:47.536480528-08:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,10 +12,10 @@ description: Mastodon is a free, open-source social network server based on Acti
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
+# This is the chart version. This version number should be incremented each time
+# you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.2
+version: 5.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ appVersion: v4.2.7
 
 dependencies:
   - name: elasticsearch
-    version: 19.0.1
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 19.19.2
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: postgresql
-    version: 11.1.3
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 14.2.3
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: redis
-    version: 16.13.2
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 18.16.1
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Kubernetes cluster.  The basic usage is:
 1. `helm dep update`
 1. `helm install --namespace mastodon --create-namespace my-mastodon ./ -f path/to/additional/values.yaml`
 
-This chart is tested with k8s 1.21+ and helm 3.6.0+.
+This chart is tested with k8s 1.21+ and helm 3.8.0+.
 
 # Configuration
 


### PR DESCRIPTION
supersedes https://github.com/mastodon/chart/pull/91

- redis chart [updated from 16.x to 18.x](https://github.com/bitnami/charts/tree/main/bitnami/redis#to-1800), which upgrades the default version of redis used from 6 to 7
  - [redis 7.0 changelog](https://raw.githubusercontent.com/redis/redis/7.0/00-RELEASENOTES)
  - [redis 7.2 changelog](https://raw.githubusercontent.com/redis/redis/7.2/00-RELEASENOTES)

- postgresql chart [updated from 11.x to 14.x](https://github.com/bitnami/charts/tree/main/bitnami/postgresql#to-1400)
  - updates the default version of postgresql from 14 to 16 - [upgrade notes for 14 to 15](https://www.postgresql.org/docs/15/upgrading.html) - [upgrade notes for 15 to 16](https://www.postgresql.org/docs/16/upgrading.html)
  - changes how `NetworkPolicy` objects are created