### PR TITLE
chore(deps): upgrade image tag to v4.2.7 and bump chart version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.1
+version: 4.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ image:
   # built from the most recent commit
   #
   # tag: latest
-  tag: "v4.2.5"
+  tag: "v4.2.7"
   # use `Always` when using `latest` tag
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
It seems #126 missed the upgrade to the image tag, and bumping the chart version. Easily done though as it was recently in #122 that I suggested we go with exact version in the tags.