### PR TITLE
Rollout tuning

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.1.1
+version: 5.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -19,7 +19,10 @@ spec:
       {{ fail "The scheduler queue should never have more than 1 replicas" }}
     {{- end }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 25%
   {{- end }}
   replicas: {{ .replicas }}
   {{- if (ne (toString $context.Values.mastodon.revisionHistoryLimit) "<nil>") }}

--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -19,10 +19,7 @@ spec:
       {{ fail "The scheduler queue should never have more than 1 replicas" }}
     {{- end }}
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 10%
-      maxUnavailable: 25%
+    type: Recreate
   {{- end }}
   replicas: {{ .replicas }}
   {{- if (ne (toString $context.Values.mastodon.revisionHistoryLimit) "<nil>") }}

--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -13,6 +13,11 @@ spec:
   {{- if (ne (toString .Values.mastodon.revisionHistoryLimit) "<nil>") }}
   revisionHistoryLimit: {{ .Values.mastodon.revisionHistoryLimit }}
   {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 25%
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}
@@ -135,6 +140,13 @@ spec:
             httpGet:
               path: /api/v1/streaming/health
               port: streaming
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            failureThreshold: 30
+            periodSeconds: 5
           {{- with (default .Values.resources .Values.mastodon.streaming.resources) }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -142,10 +142,10 @@ spec:
               port: streaming
           startupProbe:
             httpGet:
-              path: /health
+              path: /api/v1/streaming/health
               port: http
-            initialDelaySeconds: 15
-            failureThreshold: 30
+            initialDelaySeconds: 5
+            failureThreshold: 15
             periodSeconds: 5
           {{- with (default .Values.resources .Values.mastodon.streaming.resources) }}
           resources:

--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -14,10 +14,10 @@ spec:
   revisionHistoryLimit: {{ .Values.mastodon.revisionHistoryLimit }}
   {{- end }}
   strategy:
-   type: RollingUpdate
-   rollingUpdate:
-     maxSurge: 2
-     maxUnavailable: 25%
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 25%
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}

--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -13,6 +13,11 @@ spec:
   {{- if (ne (toString .Values.mastodon.revisionHistoryLimit) "<nil>") }}
   revisionHistoryLimit: {{ .Values.mastodon.revisionHistoryLimit }}
   {{- end }}
+  strategy:
+   type: RollingUpdate
+   rollingUpdate:
+     maxSurge: 2
+     maxUnavailable: 25%
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}
@@ -203,6 +208,7 @@ spec:
             httpGet:
               path: /health
               port: http
+            initialDelaySeconds: 15
             failureThreshold: 30
             periodSeconds: 5
           {{- with (default .Values.resources .Values.mastodon.web.resources) }}

--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -16,7 +16,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 2
+      maxSurge: 10%
       maxUnavailable: 25%
   selector:
     matchLabels:


### PR DESCRIPTION
Web pods, especially ones with many DB connections, can sometimes take more time to come back up, and have the highest user impact if they are all get replaced too quickly. This slows down how quickly web pods are swapped out, and adds a small delay in their readiness probe to allow them to get situated.