### PR TITLE
Fix mastodon-streaming failing its startup probe

### DIFF
--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -143,7 +143,7 @@ spec:
           startupProbe:
             httpGet:
               path: /api/v1/streaming/health
-              port: http
+              port: streaming
             initialDelaySeconds: 5
             failureThreshold: 15
             periodSeconds: 5


### PR DESCRIPTION
With the invalid port, the startup probe will fail to run, causing the pod to never be marked as ready and accepting connections.