### PR TITLE
Fix endpoint type for healthcheck for streaming pods

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.1.2
+version: 5.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -143,7 +143,7 @@ spec:
           startupProbe:
             httpGet:
               path: /api/v1/streaming/health
-              port: http
+              port: streaming
             initialDelaySeconds: 5
             failureThreshold: 15
             periodSeconds: 5


### PR DESCRIPTION
Endpoint type for the startup probe for the streaming pods was the incorrect type. Now fixed.