### PR TITLE
Add TRUSTED_PROXY_IP option

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -161,6 +161,9 @@ data:
   {{- with .Values.mastodon.streaming.base_url }}
   STREAMING_API_BASE_URL: {{ . | quote }}
   {{- end }}
+  {{- if .Values.mastodon.trusted_proxy_ip }}
+  TRUSTED_PROXY_IP: {{ .Values.mastodon.trusted_proxy_ip }}
+  {{ end }}
   {{- if .Values.externalAuth.oidc.enabled }}
   OIDC_ENABLED: {{ .Values.externalAuth.oidc.enabled | quote }}
   OIDC_DISPLAY_NAME: {{ .Values.externalAuth.oidc.display_name }}

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,9 @@ mastodon:
   # -- If you have multiple domains pointed at your Mastodon server, this setting will allow Mastodon to recognize
   # itself when users are addressed using those other domains.
   alternate_domains: []
+  # -- Comma-separated list of public IP addresses of trusted reverse proxy servers reaching Mastodon web and streaming servers
+  # Specifying overrides default list. More info: https://docs.joinmastodon.org/admin/config/#trusted_proxy_ip
+  # trusted_proxy_ip:
   # -- If set to true, the frontpage of your Mastodon server will always redirect to the first profile in the database and registrations will be disabled.
   singleUserMode: false
   # -- Enables "Secure Mode" for more details see: https://docs.joinmastodon.org/admin/config/#authorized_fetch


### PR DESCRIPTION
Mastodon [v4.2.9](https://github.com/mastodon/mastodon/releases/tag/v4.2.9) started performing stricter checks to prevent client IP address spoofing. This environmental variable is required for use behind reverse proxy servers.