### PR TITLE
Use .Values.image.tag for app.kubernetes.io/version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.3.3
+version: 5.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -48,7 +48,7 @@ helm.sh/chart: {{ include "mastodon.chart" . }}
 {{ include "mastodon.selectorLabels" . }}
 {{ include "mastodon.globalLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}


### PR DESCRIPTION
When specifiying a different `image.tag` version, the resulting image definitions will use this tag, but the helm labels `app.kubernetes.io/version` values would still use the AppVersion from `Chart.yaml`.


Before:

```sh
$ helm template -f dev-values.yaml --set image.tag=1.2.3 . |grep -E '(4.2.8|1.2.3)'
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "v4.2.8"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "v4.2.8"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "v4.2.8"
              image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
    app.kubernetes.io/version: "v4.2.8"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "v4.2.8"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "v4.2.8"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
```

With this PR: 

```sh
 $ helm template -f dev-values.yaml --set image.tag=1.2.3 . |grep -E '(4.2.8|1.2.3)'
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
        checksum/config-secrets: "02dbb4d23850e2f2d1502951426916d5117c01338e80b5e5cea0bd474973859d"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "1.2.3"
        checksum/config-secrets: "02dbb4d23850e2f2d1502951426916d5117c01338e80b5e5cea0bd474973859d"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "1.2.3"
        checksum/config-secrets: "02dbb4d23850e2f2d1502951426916d5117c01338e80b5e5cea0bd474973859d"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "1.2.3"
              image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
    app.kubernetes.io/version: "1.2.3"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "1.2.3"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
    app.kubernetes.io/version: "1.2.3"
          image: "ghcr.io/mastodon/mastodon:1.2.3"
```