### PR TITLE
Better control of labels/annotations for deployments and pods

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.3.3
+version: 5.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -7,10 +7,16 @@ metadata:
   name: {{ include "mastodon.fullname" $context }}-sidekiq-{{ .name }}
   labels:
     {{- include "mastodon.labels" $context | nindent 4 }}
+    {{- with $context.Values.mastodon.sidekiq.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/component: sidekiq-{{ .name }}
     app.kubernetes.io/part-of: rails
   annotations:
     {{- with $context.Values.deploymentAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $context.Values.mastodon.sidekiq.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -37,6 +43,9 @@ spec:
         {{- with $context.Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with $context.Values.mastodon.sidekiq.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         # roll the pods to pick up any db migrations or other changes
         {{- include "mastodon.rollingPodAnnotations" $context | nindent 8 }}
         checksum/config-secrets-smtp: {{ include ( print $.Template.BasePath "/secret-smtp.yaml" ) $context | sha256sum | quote }}
@@ -44,6 +53,9 @@ spec:
         {{- include "mastodon.globalLabels" $context | nindent 8 }}
         {{- include "mastodon.selectorLabels" $context | nindent 8 }}
         {{- include "mastodon.statsdExporterLabels" $context | nindent 8 }}
+        {{- with $context.Values.mastodon.sidekiq.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/component: sidekiq-{{ .name }}
         app.kubernetes.io/part-of: rails
     spec:

--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- with .Values.deploymentAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.mastodon.web.annotations }}
+    {{- with .Values.mastodon.streaming.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -19,8 +19,8 @@ spec:
   {{- if (ne (toString .Values.mastodon.revisionHistoryLimit) "<nil>") }}
   revisionHistoryLimit: {{ .Values.mastodon.revisionHistoryLimit }}
   {{- end }}
-  {{- if .Values.mastodon.web.updateStrategy }}
-  strategy: {{- toYaml .Values.mastodon.web.updateStrategy | nindent 4 }}
+  {{- if .Values.mastodon.streaming.updateStrategy }}
+  strategy: {{- toYaml .Values.mastodon.streaming.updateStrategy | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -4,8 +4,14 @@ metadata:
   name: {{ include "mastodon.fullname" . }}-streaming
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}
+    {{- with .Values.mastodon.streaming.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
-    {{- with (default .Values.deploymentAnnotations .Values.mastodon.streaming.deploymentAnnotations) }}
+    {{- with .Values.deploymentAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.mastodon.web.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -23,7 +29,10 @@ spec:
   template:
     metadata:
       annotations:
-        {{- with (default .Values.podAnnotations .Values.mastodon.streaming.podAnnotations) }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.mastodon.streaming.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         # roll the pods to pick up any db migrations or other changes
@@ -31,6 +40,9 @@ spec:
       labels:
         {{- include "mastodon.globalLabels" . | nindent 8 }}
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
+        {{- with .Values.mastodon.streaming.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/component: streaming
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -4,8 +4,14 @@ metadata:
   name: {{ include "mastodon.fullname" . }}-web
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}
+    {{- with .Values.mastodon.web.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
-    {{- with (default .Values.deploymentAnnotations .Values.mastodon.web.deploymentAnnotations) }}
+    {{- with .Values.deploymentAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.mastodon.web.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -24,7 +30,10 @@ spec:
   template:
     metadata:
       annotations:
-        {{- with (default .Values.podAnnotations .Values.mastodon.web.podAnnotations) }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.mastodon.web.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         # roll the pods to pick up any db migrations or other changes
@@ -33,6 +42,9 @@ spec:
         {{- include "mastodon.globalLabels" . | nindent 8 }}
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
         {{- include "mastodon.statsdExporterLabels" . | nindent 8 }}
+        {{- with .Values.mastodon.web.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/component: web
         app.kubernetes.io/part-of: rails
     spec:

--- a/values.yaml
+++ b/values.yaml
@@ -141,6 +141,18 @@ mastodon:
     resources: {}
     # -- Affinity for all Sidekiq Deployments unless overwritten, overwrites .Values.affinity
     affinity: {}
+    # -- Annotations to apply to the deployment object(s) for sidekiq.
+    # -- These are applied in addition to deploymentAnnotations.
+    annotations: {}
+    # -- Labels to apply to the deployment object(s) for sidekiq.
+    # -- These are applied in addition to mastodon.labels.
+    labels: {}
+    # -- Annotations to apply to the sidekiq pods.
+    # -- These are applied in addition to the global podAnnotations.
+    podAnnotations: {}
+    # -- Labels to apply to the sidekiq pods.
+    # -- These are applied in addition to mastodon.labels.
+    podLabels: {}
     # Rollout strategy to use when updating pods.
     # Recreate will help reduce the number of retried jobs when updating when
     # the code introduces a new job as the pods are all replaced immediately.
@@ -255,6 +267,18 @@ mastodon:
     replicas: 1
     # -- Affinity for Streaming Pods, overwrites .Values.affinity
     affinity: {}
+    # -- Annotations to apply to the deployment object for streaming.
+    # -- These are applied in addition to deploymentAnnotations.
+    annotations: {}
+    # -- Labels to apply to the deployment object for streaming.
+    # -- These are applied in addition to mastodon.labels.
+    labels: {}
+    # -- Annotations to apply to the streaming pods.
+    # -- These are applied in addition to the global podAnnotations.
+    podAnnotations: {}
+    # -- Labels to apply to the streaming pods.
+    # -- These are applied in addition to mastodon.labels.
+    podLabels: {}
     # Rollout strategy to use when updating pods
     # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
     updateStrategy:
@@ -301,6 +325,18 @@ mastodon:
     replicas: 1
     # -- Affinity for Web Pods, overwrites .Values.affinity
     affinity: {}
+    # -- Annotations to apply to the deployment object for web.
+    # -- These are applied in addition to deploymentAnnotations.
+    annotations: {}
+    # -- Labels to apply to the deployment object for web.
+    # -- These are applied in addition to mastodon.labels.
+    labels: {}
+    # -- Annotations to apply to the web pods.
+    # -- These are applied in addition to the global podAnnotations.
+    podAnnotations: {}
+    # -- Labels to apply to the web pods.
+    # -- These are applied in addition to mastodon.labels.
+    podLabels: {}
     # Rollout strategy to use when updating pods
     # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
     updateStrategy:


### PR DESCRIPTION
There have been several situations where I've needed to assign labels/annotations to either deployment objects themselves, and/or the resulting pods. There are already some mechanisms for this in the chart, but they are not documented in `values.yaml`, or override other global fields.

This adds additional fields to each of the components to allow for custom, deployment- or pod-specific labels and annotations that are applied in addition to any global annotations and labels.