### PR TITLE
S3 upload

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.4.0
+version: 5.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/job-assets-copy.yaml
+++ b/templates/job-assets-copy.yaml
@@ -60,6 +60,9 @@ spec:
               secretKeyRef:
                 name: {{ required "Please specify a secret with S3 credentials for S3 asset uploads" .Values.mastodon.hooks.s3Upload.secretRef.name }}
                 key: {{ .Values.mastodon.hooks.s3Upload.secretRef.keys.secretAccessKey }}
+          {{- with .Values.mastodon.hooks.s3Upload.rclone.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
           - rclone
           args:

--- a/templates/job-assets-copy.yaml
+++ b/templates/job-assets-copy.yaml
@@ -66,6 +66,10 @@ spec:
           - copy
           - /assets/public
           - "remote:{{ required "Please specify a bucket for S3 asset uploads" .Values.mastodon.hooks.s3Upload.bucket }}"
+          - --fast-list
+          - --transfers=32
+          - --include
+          - "{assets,packs}/**"
           - --progress
           - -vv
           volumeMounts:

--- a/templates/job-assets-copy.yaml
+++ b/templates/job-assets-copy.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.mastodon.hooks.s3Upload.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "mastodon.fullname" . }}-assets-upload
+  labels:
+    {{- include "mastodon.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-1"
+spec:
+  template:
+    metadata:
+      name: {{ include "mastodon.fullname" . }}-assets-upload
+      {{- with .Values.jobAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}      volumes:
+      restartPolicy: Never
+      initContainers:
+        - name: extract-assets
+          image: "{{ coalesce .Values.mastodon.web.image.repository .Values.image.repository }}:{{ coalesce .Values.mastodon.web.image.tag .Values.image.tag .Chart.AppVersion }}"
+          imagePullPolicy: Always
+          command:
+          - cp
+          args:
+          - -rv
+          - public
+          - /assets
+          volumeMounts:
+            - mountPath: /assets
+              name: assets
+      containers:
+        - name: upload-assets
+          image: rclone/rclone:1
+          imagePullPolicy: Always
+          env:
+          - name: RCLONE_S3_NO_CHECK_BUCKET
+            value: "true"
+          - name: RCLONE_CONFIG_REMOTE_TYPE
+            value: s3
+          - name: RCLONE_CONFIG_REMOTE_PROVIDER
+            value: AWS
+          - name: RCLONE_CONFIG_REMOTE_ENDPOINT
+            value: {{ .Values.mastodon.hooks.s3Upload.endpoint }}
+          - name: RCLONE_CONFIG_REMOTE_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.mastodon.hooks.s3Upload.secretRef.name }}
+                key: {{ .Values.mastodon.hooks.s3Upload.secretRef.keys.accesKeyId }}
+          - name: RCLONE_CONFIG_REMOTE_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.mastodon.hooks.s3Upload.secretRef.name }}
+                key: {{ .Values.mastodon.hooks.s3Upload.secretRef.keys.secretAccessKey }}
+          command:
+          - rclone
+          args:
+          - copy
+          - /assets/public
+          - exo # defined in the env variable name above
+          - --progress
+          - -vv
+          volumeMounts:
+            - mountPath: /assets
+              name: assets
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 500Mi
+        - name: assets
+          emptyDir: {}
+{{- end -}}

--- a/templates/job-assets-copy.yaml
+++ b/templates/job-assets-copy.yaml
@@ -21,7 +21,8 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}      volumes:
+      {{- end }}
+      volumes:
       restartPolicy: Never
       initContainers:
         - name: extract-assets
@@ -48,23 +49,23 @@ spec:
           - name: RCLONE_CONFIG_REMOTE_PROVIDER
             value: AWS
           - name: RCLONE_CONFIG_REMOTE_ENDPOINT
-            value: {{ .Values.mastodon.hooks.s3Upload.endpoint }}
+            value: {{ required "Please specify an endpoint for S3 asset uploads" .Values.mastodon.hooks.s3Upload.endpoint }}
           - name: RCLONE_CONFIG_REMOTE_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.mastodon.hooks.s3Upload.secretRef.name }}
+                name: {{ required "Please specify a secret with S3 credentials for S3 asset uploads" .Values.mastodon.hooks.s3Upload.secretRef.name }}
                 key: {{ .Values.mastodon.hooks.s3Upload.secretRef.keys.accesKeyId }}
           - name: RCLONE_CONFIG_REMOTE_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.mastodon.hooks.s3Upload.secretRef.name }}
+                name: {{ required "Please specify a secret with S3 credentials for S3 asset uploads" .Values.mastodon.hooks.s3Upload.secretRef.name }}
                 key: {{ .Values.mastodon.hooks.s3Upload.secretRef.keys.secretAccessKey }}
           command:
           - rclone
           args:
           - copy
           - /assets/public
-          - exo # defined in the env variable name above
+          - "remote:{{ required "Please specify a bucket for S3 asset uploads" .Values.mastodon.hooks.s3Upload.bucket }}"
           - --progress
           - -vv
           volumeMounts:
@@ -76,6 +77,7 @@ spec:
               memory: 256Mi
             limits:
               memory: 500Mi
+      volumes:
         - name: assets
           emptyDir: {}
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,7 @@ mastodon:
       enabled: true
     assetsPrecompile:
       enabled: true
-    # Upload website assets to S3 before deploying.
+    # Upload website assets to S3 before deploying using rclone.
     # Whenever there is an update to Mastodon, sometimes there are assets files
     # that are renamed. As the pods are getting redeployed, and old/new pods are
     # present simultaneously, there is a chance that old asset files are
@@ -46,6 +46,9 @@ mastodon:
         keys:
           accesKeyId: acces-key-id
           secretAccessKey: secret-access-key
+      rclone:
+        # Any additional environment variables to pass to rclone.
+        env: {}
   # Custom labels to add to kubernetes resources
   #labels:
   cron:

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,12 @@ mastodon:
       enabled: true
     assetsPrecompile:
       enabled: true
-    # Upload website assets to S3 before deploying
+    # Upload website assets to S3 before deploying.
+    # Whenever there is an update to Mastodon, sometimes there are assets files
+    # that are renamed. As the pods are getting redeployed, and old/new pods are
+    # present simultaneously, that old asset files are requested from pods that
+    # don't have them anymore. Uploading asset files to S3 in this manner solves
+    # this potential conflict.
     s3Upload:
       enabled: false
       endpoint:

--- a/values.yaml
+++ b/values.yaml
@@ -32,7 +32,7 @@ mastodon:
     # Whenever there is an update to Mastodon, sometimes there are assets files
     # that are renamed. As the pods are getting redeployed, and old/new pods are
     # present simultaneously, there is a chance that old asset files are
-    # requested from pods that don't have them anymore. Uploading asset files to
+    # requested from pods that don't have them anymore, or new asset files are requested from old pods. Uploading asset files to
     # S3 in this manner solves this potential conflict.
     s3Upload:
       enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -31,9 +31,9 @@ mastodon:
     # Upload website assets to S3 before deploying.
     # Whenever there is an update to Mastodon, sometimes there are assets files
     # that are renamed. As the pods are getting redeployed, and old/new pods are
-    # present simultaneously, that old asset files are requested from pods that
-    # don't have them anymore. Uploading asset files to S3 in this manner solves
-    # this potential conflict.
+    # present simultaneously, there is a change that old asset files are
+    # requested from pods that don't have them anymore. Uploading asset files to
+    # S3 in this manner solves this potential conflict.
     s3Upload:
       enabled: false
       endpoint:

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,16 @@ mastodon:
       enabled: true
     assetsPrecompile:
       enabled: true
+    # Upload website assets to S3 before deploying
+    s3Upload:
+      enabled: false
+      endpoint:
+      bucket:
+      secretRef:
+        name:
+        keys:
+          accesKeyId: acces-key-id
+          secretAccessKey: secret-access-key
   # Custom labels to add to kubernetes resources
   #labels:
   cron:

--- a/values.yaml
+++ b/values.yaml
@@ -31,7 +31,7 @@ mastodon:
     # Upload website assets to S3 before deploying.
     # Whenever there is an update to Mastodon, sometimes there are assets files
     # that are renamed. As the pods are getting redeployed, and old/new pods are
-    # present simultaneously, there is a change that old asset files are
+    # present simultaneously, there is a chance that old asset files are
     # requested from pods that don't have them anymore. Uploading asset files to
     # S3 in this manner solves this potential conflict.
     s3Upload:

--- a/values.yaml
+++ b/values.yaml
@@ -32,8 +32,11 @@ mastodon:
     # Whenever there is an update to Mastodon, sometimes there are assets files
     # that are renamed. As the pods are getting redeployed, and old/new pods are
     # present simultaneously, there is a chance that old asset files are
-    # requested from pods that don't have them anymore, or new asset files are requested from old pods. Uploading asset files to
-    # S3 in this manner solves this potential conflict.
+    # requested from pods that don't have them anymore, or new asset files are
+    # requested from old pods. Uploading asset files to S3 in this manner solves
+    # this potential conflict.
+    # Note that you will need to CDN/proxy to send all requests to /assets and
+    # /packs to this bucket.
     s3Upload:
       enabled: false
       endpoint:


### PR DESCRIPTION
Added a job to upload assets to an S3 bucket on helm chart creation. Tested this in an isolated situation outside of a chart, and the job successfully uploads to exoscale, so the actual job definition works. Haven't tested it in the actual chart itself yet.

One note: this uploads the entire `/public` folder. Not sure if this is the "correct" thing to do or not, or if just `/public/assets` should be uploaded. Let me know if this should be changed.