### PR TITLE
set default for `streaming.image.repository` in values.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.5.2
+version: 5.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/values.yaml
+++ b/values.yaml
@@ -276,8 +276,8 @@ mastodon:
     existingSecret:
   streaming:
     image:
-      repository:
-      tag:
+      repository: ghcr.io/mastodon/mastodon-streaming
+      tag: ""
     port: 4000
     # -- this should be set manually since os.cpus() returns the number of CPUs on
     # the node running the pod, which is unrelated to the resources allocated to


### PR DESCRIPTION
Sets default to `ghcr.io/mastodon/mastodon-streaming` as is suggested in:
https://github.com/mastodon/mastodon/blob/16597fa73547f5f894342711ad081a36bd34ee03/docker-compose.yml#L81-L89

By default, the chart uses the default mastodon image, which will not work, as I found out here:
https://github.com/mastodon/mastodon/discussions/32623