### PR TITLE
Use sidekiq concurrency field to set DB_POOL

### DIFF
--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -122,6 +122,8 @@ spec:
                 name: {{ $context.Values.mastodon.extraEnvFrom }}
             {{- end}}
           env:
+            - name: "DB_POOL"
+              value: {{ (max (int .concurrency) 1) | quote }}
             - name: "DB_PASS"
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
There are really two stages to this PR to consider.

The easy one is allowing deployment-sidekiq to set the `DB_POOL` env variable per sidekiq worker definition. The second one specifically sets it to the concurrency value rather than using an independent key. My memory is that sidekiq should never need more DB connections than it has threads, so this reduces connection overhead for workers with low duty cycles (eg a worker dedicated to one of the scheduler, mailers, and potentially ingress queues).