### PR TITLE
Make sure to quote replica db port value

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -19,7 +19,7 @@ data:
   REPLICA_DB_HOST: {{ .Values.postgresql.readReplica.hostname }}
   {{- end }}
   {{- if .Values.postgresql.readReplica.port }}
-  REPLICA_DB_PORT: {{ .Values.postgresql.readReplica.port }}
+  REPLICA_DB_PORT: {{ .Values.postgresql.readReplica.port | quote }}
   {{- end }}
   {{- if .Values.postgresql.readReplica.auth.database }}
   REPLICA_DB_NAME: {{ .Values.postgresql.readReplica.auth.database }}


### PR DESCRIPTION
Latest version will not deploy to kubernetes without it being quoted. See the following:
```
$ helm upgrade --install -n mastodon mastodon chart/ -f values.yaml
Error: UPGRADE FAILED: failed to create resource: ConfigMap in version "v1" cannot be handled as a ConfigMap: json: cannot unmarshal number into Go struct field ConfigMap.data of type string
```

With these values:
```
postgresql:
  enabled: false
  postgresqlHostname: mastodon-db
  kubepostgresqlPort: "5432"
  auth:
    database: mastodon
    username: mastodon
    existingSecret: "mastodon.mastodon-db.credentials.postgresql.acid.zalan.do"

  readReplica:
    hostname: mastodon-db-repl
    port: "5432"
    auth:
      database: mastodon
      username: mastodon
      existingSecret: "mastodon.mastodon-db.credentials.postgresql.acid.zalan.do"
```

It being quoted (or not) in values doesn't matter in this case, adding this will fix the error and make the chart deployable