### PR TITLE
Added additional DB connection fields to deal with connection pooler migrations

### DIFF
--- a/templates/_db-migrate.tpl
+++ b/templates/_db-migrate.tpl
@@ -57,11 +57,11 @@ spec:
                 {{- end }}
           env:
             - name: "DB_HOST"
-              value: {{ template "mastodon.postgres.host" . }}
+              value: {{ template "mastodon.postgres.direct.host" . }}
             - name: "DB_PORT"
-              value: {{ template "mastodon.postgres.port" . }}
+              value: {{ template "mastodon.postgres.direct.port" . }}
             - name: "DB_NAME"
-              value: {{ .Values.postgresql.auth.database }}
+              value: {{ template "mastodon.postgres.direct.database" . }}
             - name: "DB_USER"
               value: {{ .Values.postgresql.auth.username }}
             - name: "DB_PASS"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -140,6 +140,33 @@ Establish which values we will use for remote connections
 {{- end }}
 {{- end }}
 
+{{/*
+Establish which values we will use for direct remote DB connections
+*/}}
+{{- define "mastodon.postgres.direct.host" -}}
+{{- if .Values.postgresql.direct.hostname }}
+{{- printf "%s" .Values.postgresql.direct.hostname -}}
+{{- else }}
+{{- printf "%s" (include "mastodon.postgres.host" .) -}}
+{{- end }}
+{{- end }}
+
+{{- define "mastodon.postgres.direct.port" -}}
+{{- if .Values.postgresql.direct.port }}
+{{- printf "%d" (int .Values.postgresql.direct.port) | quote -}}
+{{- else }}
+{{- printf "%s" (include "mastodon.postgres.port" .) -}}
+{{- end }}
+{{- end }}
+
+{{- define "mastodon.postgres.direct.database" -}}
+{{- if .Values.postgresql.direct.database }}
+{{- printf "%s" .Values.postgresql.direct.database -}}
+{{- else }}
+{{- printf "%s" .Values.postgresql.auth.database -}}
+{{- end }}
+{{- end }}
+
 {{- define "mastodon.redis.host" -}}
 {{- if .Values.redis.enabled }}
 {{- printf "%s-%s" (include "mastodon.redis.fullname" .) "master" -}}

--- a/values.yaml
+++ b/values.yaml
@@ -532,6 +532,16 @@ postgresql:
   enabled: true
   # postgresqlHostname: preexisting-postgresql
   # postgresqlPort: 5432
+
+  # If using a connection pooler such as pgbouncer, please specify a hostname/IP
+  # that serves as a "direct" connection to the database, rather than going
+  # through the connection pooler. This is required for migrations to work
+  # properly.
+  direct:
+    hostname:
+    port:
+    database:
+
   auth:
     database: mastodon_production
     username: mastodon


### PR DESCRIPTION
When using a connection pooler like pgbouncer, migrations will fail when being done through the pooler. The solution is to provide a "direct" connection to the migration pods so they don't run into this issue.

Fixes #168 