### PR TITLE
Fix some helm typos (comments interfering with manifests)

### DIFF
--- a/templates/job-db-prepare.yaml
+++ b/templates/job-db-prepare.yaml
@@ -1,4 +1,3 @@
-# Does not work with included database because of helm install order.
 {{- if not .Values.postgresql.enabled }}
 {{- include "mastodon.dbMigrateJob" (merge (dict "prepare" true ) .) }}
 {{- end }}

--- a/templates/secret-prepare.yml
+++ b/templates/secret-prepare.yml
@@ -1,4 +1,3 @@
-# Does not work with included database because of helm install order.
 {{- if and (include "mastodon.createSecret" .) (not .Values.postgresql.enabled) -}}
 {{- include "mastodon.secrets.object" (merge (dict "prepare" true ) .) }}
 {{- end }}


### PR DESCRIPTION
Discovered a really silly bug with how templates + comments work. This fixes it.