### PR TITLE
Fix ordering for db:prepare and db:migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 6.0.1
+
+- Added additional values to separate out `db:prepare` and `db:migrate` jobs and whether they should run:
+```yaml
+mastodon:
+  hooks:
+    dbPrepare:
+      enabled: true
+    dbMigrate:
+      enabled: true
+```
+
 # 6.0.0
 
 ### !! BREAKING CHANGES !!

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.0.0
+version: 6.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/_db-migrate.tpl
+++ b/templates/_db-migrate.tpl
@@ -24,7 +24,11 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     {{- end }}
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- if .prepare }}
+    "helm.sh/hook-weight": "-3"
+    {{- else }}
     "helm.sh/hook-weight": "-2"
+    {{- end }}
 spec:
   template:
     metadata:

--- a/templates/job-db-prepare.yaml
+++ b/templates/job-db-prepare.yaml
@@ -1,3 +1,3 @@
-{{- if and .Values.mastodon.hooks.dbMigrate.enabled (not .Values.postgresql.enabled) }}
+{{- if and .Values.mastodon.hooks.dbPrepare.enabled (not .Values.postgresql.enabled) }}
 {{- include "mastodon.dbMigrateJob" (merge (dict "prepare" true ) .) }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -24,9 +24,12 @@ mastodon:
     # @ignored
     email: not@example.com
   hooks:
-    # Whether to perform DB preparations & migrations on `helm install|upgrade`.
-    # Please note that initial DB schema creation on `helm install` does not
-    # work when using the included database (postgresql.enabled=true).
+    # Whether to perform DB schema creation on `helm install`.
+    # Please note that this does not work when using the included database
+    # (postgresql.enabled=true).
+    dbPrepare:
+      enabled: true
+    # Whether to perform DB migrations on `helm upgrade`.
     dbMigrate:
       enabled: true
     # Upload website assets to S3 before deploying using rclone.

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,9 @@ mastodon:
     # Whether to perform DB schema creation on `helm install`.
     # Please note that this does not work when using the included database
     # (postgresql.enabled=true).
+    # NOTE: When using certain GitOps solutions such as Argo CD, this should be
+    # disabled, as these apps do not necessarily differentiate between `pre-install`
+    # and `pre-upgrade`.
     dbPrepare:
       enabled: true
     # Whether to perform DB migrations on `helm upgrade`.


### PR DESCRIPTION
For situations where someone is using something like Argo CD (which doesn't differentiate between `pre-install` and `pre-upgrade` jobs can be run at the same time. Which is fine ultimately, but can sometimes result in colliding jobs. This should fix that.