### PR TITLE
Don't use common.names.fullname; fix error with null postgresql hostname

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -92,7 +92,7 @@ Create the name of the assets persistent volume to use
 {{- if .Values.mastodon.persistence.assets.existingClaim }}
     {{- printf "%s" (tpl .Values.mastodon.persistence.assets.existingClaim $) -}}
 {{- else -}}
-    {{- printf "%s-assets" (include "common.names.fullname" .) -}}
+    {{- printf "%s-assets" (include "mastodon.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -103,7 +103,7 @@ Create the name of the system persistent volume to use
 {{- if .Values.mastodon.persistence.system.existingClaim }}
     {{- printf "%s" (tpl .Values.mastodon.persistence.system.existingClaim $) -}}
 {{- else -}}
-    {{- printf "%s-system" (include "common.names.fullname" .) -}}
+    {{- printf "%s-system" (include "mastodon.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -130,7 +130,7 @@ Establish which values we will use for remote connections
 {{- if .Values.postgresql.enabled }}
 {{- printf "%s" (include "mastodon.postgresql.fullname" .) -}}
 {{- else }}
-{{- printf "%s" .Values.postgresql.postgresqlHostname -}}
+{{- printf "%s" (required "When the postgresql chart is disabled .Values.postgresql.postgresqlHostname is required" .Values.postgresql.postgresqlHostname) -}}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
We've already replaced `common.names.fullname` in most places, there were just a few left.
Also uncovered a null value error when testing, that has also been fixed.

Closes issue #119 