### PR TITLE
Don't include entire digest versions in app version label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.2.2
 
--  `app.kubernetes.io/version` shortens any potential digest hash to 7 characters to avoid hitting the 63 character lable limit.
+-  `app.kubernetes.io/version` shortens any potential digest hash to 7 characters to avoid hitting the 63 character label limit.
 
 # 6.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.2.2
+
+-  `app.kubernetes.io/version` no longer inlcudes digests when specified, as they can often go over the 63 character limit.
+
 # 6.2.1
 
 - Fixed some situations where disabling all bitnami charts caused it to error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.2.2
 
--  `app.kubernetes.io/version` no longer inlcudes digests when specified, as they can often go over the 63 character limit.
+-  `app.kubernetes.io/version` no longer includes digests when specified, as they can often go over the 63 character limit.
 
 # 6.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.2.2
 
--  `app.kubernetes.io/version` no longer includes digests when specified, as they can often go over the 63 character limit.
+-  `app.kubernetes.io/version` shortens any potential digest hash to 7 characters to avoid hitting the 63 character lable limit.
 
 # 6.2.1
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.2.1
+version: 6.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -48,7 +48,7 @@ helm.sh/chart: {{ include "mastodon.chart" . }}
 {{ include "mastodon.selectorLabels" . }}
 {{ include "mastodon.globalLabels" . }}
 {{- if .Values.image.tag }}
-app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+app.kubernetes.io/version: {{ regexReplaceAll "@[a-zA-Z0-9:]+" .Values.image.tag "" | quote }}
 {{- else if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -48,7 +48,7 @@ helm.sh/chart: {{ include "mastodon.chart" . }}
 {{ include "mastodon.selectorLabels" . }}
 {{ include "mastodon.globalLabels" . }}
 {{- if .Values.image.tag }}
-app.kubernetes.io/version: {{ regexReplaceAll "@[a-zA-Z0-9:]+" .Values.image.tag "" | quote }}
+app.kubernetes.io/version: {{ regexReplaceAll "@(\\w+:\\w{0,7})\\w*" .Values.image.tag "@${1}" | quote }}
 {{- else if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}


### PR DESCRIPTION
Shortens any digest information from the image tag when filling out `app.kubernetes.io/version`, to only 7 characters of the hash, as this often runs over the 63 character limit.

For example:
`image:tag@sha256:a86ee592e88df1b85951a1d895f487c3549beb3f57da4ceb7d8ca9d6992d5da9`
becomes
`image:tag@sha256:a86ee59`