### PR TITLE
Resolve the situation where Job mastodon-db-prepare cannot complete processing due to the absence of Secret mastodon-redis by adjusting the hook for Secret mastodon-redis

### DIFF
--- a/templates/secret-redis.yaml
+++ b/templates/secret-redis.yaml
@@ -7,6 +7,9 @@ metadata:
   name: {{ include "mastodon.redis.secretName" . }}
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-10"
 type: Opaque
 data:
   redis-password: "{{ .Values.redis.auth.password | b64enc }}"


### PR DESCRIPTION
Hello
I recently installed mastodon on my cluster using this helm chart.
For the purposes of this discussion, let's call the release mastodon.
At that time, I encountered a situation where Job mastodon-db-prepare could not complete processing due to the absence of Secret mastodon-redis.
When I checked the contents of the chart, I found that Job mastodon-db-prepare was created by the helm pre-install hook, while Secret mastodon-redis was created by the normal process.
So I created a patch to adjust the hook and hook-weight of Secret mastodon-redis to solve the problem.

I would be grateful if you could consider merging it.
Thank you.
