### PR TITLE
Fix redis secret from values not being used in db-prepare

### DIFF
--- a/templates/_db-migrate.tpl
+++ b/templates/_db-migrate.tpl
@@ -102,7 +102,15 @@ spec:
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
+                  {{- if .prepare }}
+                  {{- if and (not .Values.redis.enabled) (and (not .Values.redis.auth.existingSecret) (not .Values.redis.existingSecret)) (.Values.redis.auth.password) }}
+                  name: {{ template "mastodon.redis.secretName" . }}-pre-install
+                  {{- else }}
                   name: {{ template "mastodon.redis.secretName" . }}
+                  {{- end }}
+                  {{- else }}
+                  name: {{ template "mastodon.redis.secretName" . }}
+                  {{- end }}
                   key: redis-password
           {{- if .preDeploy }}
             - name: "SKIP_POST_DEPLOYMENT_MIGRATIONS"

--- a/templates/secret-redis-preinstall.yaml
+++ b/templates/secret-redis-preinstall.yaml
@@ -1,0 +1,19 @@
+{{- if not .Values.redis.enabled }}
+{{- if and (not .Values.redis.auth.existingSecret) (not .Values.redis.existingSecret) }}
+{{- if .Values.redis.auth.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mastodon.redis.secretName" . }}-pre-install
+  labels:
+    {{- include "mastodon.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+type: Opaque
+data:
+  redis-password: "{{ .Values.redis.auth.password | b64enc }}"
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Alternate proposal for PR #187 from @kaznak
Fixes issue #188 

When a redis secret is specified in values or the helm CLI, it doesn't get used by the db-prepare job. This should fix that.