### PR TITLE
Remove DB_POOL from configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.3.1
+
+- Removed DB_POOL from the ConfigMap as we should never have to override this.
+
 # 6.3.0
 
 - Added `nodeSelector` fields for every resource type for better fine-grain tuning of where resources end up.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.3.0
+version: 6.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -271,18 +271,6 @@ Return true if a mastodon secret object should be created
 {{- end -}}
 
 {{/*
-Find highest number of needed database connections to set DB_POOL variable
-*/}}
-{{- define "mastodon.maxDbPool" -}}
-{{/* Default MAX_THREADS for Puma is 5 */}}
-{{- $poolSize := 5 }}
-{{- range .Values.mastodon.sidekiq.workers }}
-{{- $poolSize = max $poolSize .concurrency }}
-{{- end }}
-{{- $poolSize | quote }}
-{{- end }}
-
-{{/*
 Full hostname for a custom Elasticsearch cluster
 */}}
 {{- define "mastodon.elasticsearch.fullHostname" -}}

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -8,7 +8,6 @@ data:
   DB_HOST: {{ template "mastodon.postgres.host" . }}
   DB_PORT: {{ template "mastodon.postgres.port" . }}
   DB_NAME: {{ .Values.postgresql.auth.database }}
-  DB_POOL: {{ include "mastodon.maxDbPool" . }}
   DB_USER: {{ .Values.postgresql.auth.username }}
   {{- if .Values.postgresql.readReplica.hostname }}
   REPLICA_DB_HOST: {{ .Values.postgresql.readReplica.hostname }}


### PR DESCRIPTION
Response to the discussion in PR #160. Removes `DB_POOL` override.