### PR TITLE
Support FETCH_REPLIES_* environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.4.0
+
+- Added `fetchReplies` values
+
 # 6.3.3
 
 - Updated the Mastodon version to v4.3.8

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -28,6 +28,16 @@ data:
   {{- if .Values.mastodon.locale }}
   DEFAULT_LOCALE: {{ .Values.mastodon.locale }}
   {{- end }}
+  {{- with .Values.fetchReplies }}
+  {{- if .enabled }}
+  FETCH_REPLIES_ENABLED: "true"
+  FETCH_REPLIES_COOLDOWN_MINUTES: {{ .cooldownMinutes | default "15" | quote }}
+  FETCH_REPLIES_INITIAL_WAIT_MINUTES: {{ .initialWaitMinutes | default "5" | quote }}
+  FETCH_REPLIES_MAX_GLOBAL: {{ .maxGlobal | default "1000" | quote }}
+  FETCH_REPLIES_MAX_SINGLE: {{ .maxSingle | default "500" | quote }}
+  FETCH_REPLIES_MAX_PAGES: {{ .maxPages | default "500" | quote }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.elasticsearch.enabled }}
   ES_ENABLED: "true"
   ES_PRESET: {{ .Values.elasticsearch.preset | default "single_node_cluster" | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -133,6 +133,19 @@ mastodon:
   authorizedFetch: false
   # -- Enables "Limited Federation Mode" for more details see: https://docs.joinmastodon.org/admin/config/#limited_federation_mode
   limitedFederationMode: false
+  fetchReplies:
+    # -- Enables fetching additional replies when a post's detailed view is expanded.
+    enabled: false
+    # -- The amount of time to wait since the last fetch of a post and its replies since the last fetch
+    cooldownMinutes: 15
+    # -- The amount of time after a post was created to wait before it is eligible for fetching replies
+    initialWaitMinutes: 5
+    # -- The maximum number of replies to fetch - total
+    maxGlobal: 1000
+    # -- The maximum number of replies to fetch for a single status
+    maxSingle: 500
+    # -- The total number of ActivityPub `Collection` pages to fetch
+    maxPages: 500
   persistence:
     assets:
       # -- ReadWriteOnce is more widely supported than ReadWriteMany, but limits


### PR DESCRIPTION
This PR prepares the chart for the `FETCH_REPLIES` feature which was merged into Mastodon main.

It should be merged once a Mastodon version with the feature is released.