### PR TITLE
Add additional configuration for redis secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 6.5.2
+
+- Added additional customization for redis secret:
+```yaml
+redis:
+  auth:
+    existingSecret:
+    existingSecretKey:
+```
+
 # 6.5.1
 
 - Updated the Mastodon version to v4.4.2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.5.1
+version: 6.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/_db-migrate.tpl
+++ b/templates/_db-migrate.tpl
@@ -107,7 +107,7 @@ spec:
                   {{- else }}
                   name: {{ template "mastodon.redis.secretName" . }}
                   {{- end }}
-                  key: redis-password
+                  key: {{ .Values.redis.auth.existingSecretKey }}
           {{- if .preDeploy }}
             - name: "SKIP_POST_DEPLOYMENT_MIGRATIONS"
               value: "true"

--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -141,20 +141,20 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.secretName" $context }}
-                  key: redis-password
+                  key: {{ $context.Values.redis.auth.existingSecretKey }}
             {{- if and $context.Values.redis.sidekiq.enabled $context.Values.redis.sidekiq.auth.existingSecret }}
             - name: "SIDEKIQ_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.sidekiq.secretName" $context }}
-                  key: redis-password
+                  key: {{ $context.Values.redis.sidekiq.auth.existingSecretKey }}
             {{- end }}
             {{- if and $context.Values.redis.cache.enabled $context.Values.redis.cache.auth.existingSecret }}
             - name: "CACHE_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.cache.secretName" $context }}
-                  key: redis-password
+                  key: {{ $context.Values.redis.cache.auth.existingSecretKey }}
             {{- end }}
             {{- if and $context.Values.elasticsearch.existingSecret (or $context.Values.elasticsearch.enabled $context.Values.elasticsearch.hostname) }}
             - name: "ES_PASS"

--- a/templates/deployment-streaming.yaml
+++ b/templates/deployment-streaming.yaml
@@ -120,20 +120,20 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.auth.existingSecretKey }}
             {{- if and .Values.redis.sidekiq.enabled .Values.redis.sidekiq.auth.existingSecret }}
             - name: "SIDEKIQ_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.sidekiq.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.sidekiq.auth.existingSecretKey }}
             {{- end }}
             {{- if and .Values.redis.cache.enabled .Values.redis.cache.auth.existingSecret }}
             - name: "CACHE_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.cache.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.cache.auth.existingSecretKey }}
             {{- end }}
             - name: "PORT"
               value: {{ .Values.mastodon.streaming.port | quote }}

--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -118,20 +118,20 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.auth.existingSecretKey }}
             {{- if and .Values.redis.sidekiq.enabled .Values.redis.sidekiq.auth.existingSecret }}
             - name: "SIDEKIQ_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.sidekiq.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.sidekiq.auth.existingSecretKey }}
             {{- end }}
             {{- if and .Values.redis.cache.enabled .Values.redis.cache.auth.existingSecret }}
             - name: "CACHE_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.cache.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.cache.auth.existingSecretKey }}
             {{- end }}
             {{- if and .Values.elasticsearch.existingSecret (or .Values.elasticsearch.enabled .Values.elasticsearch.hostname) }}
             - name: "ES_PASS"

--- a/templates/job-create-admin.yaml
+++ b/templates/job-create-admin.yaml
@@ -71,20 +71,20 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.auth.existingSecretKey }}
             {{- if and .Values.redis.sidekiq.enabled .Values.redis.sidekiq.auth.existingSecret }}
             - name: "SIDEKIQ_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.sidekiq.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.sidekiq.auth.existingSecretKey }}
             {{- end }}
             {{- if and .Values.redis.cache.enabled .Values.redis.cache.auth.existingSecret }}
             - name: "CACHE_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.cache.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.cache.auth.existingSecretKey }}
             {{- end }}
             - name: "PORT"
               value: {{ .Values.mastodon.web.port | quote }}

--- a/templates/job-deploy-search.yaml
+++ b/templates/job-deploy-search.yaml
@@ -90,7 +90,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.secretName" . }}
-                  key: redis-password
+                  key: {{ .Values.redis.auth.existingSecretKey }}
             - name: "PORT"
               value: {{ .Values.mastodon.web.port | quote }}
           {{- if (not .Values.mastodon.s3.enabled) }}

--- a/templates/secret-redis-preinstall.yaml
+++ b/templates/secret-redis-preinstall.yaml
@@ -13,7 +13,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 type: Opaque
 data:
-  redis-password: "{{ .Values.redis.auth.password | b64enc }}"
+  {{ .Values.redis.auth.existingSecretKey }}: "{{ .Values.redis.auth.password | b64enc }}"
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/secret-redis.yaml
+++ b/templates/secret-redis.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "mastodon.labels" . | nindent 4 }}
 type: Opaque
 data:
-  redis-password: "{{ .Values.redis.auth.password | b64enc }}"
+  {{ .Values.redis.auth.existingSecretKey }}: "{{ .Values.redis.auth.password | b64enc }}"
 {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -733,8 +733,9 @@ redis:
     password: ""
     # setting password for an existing redis instance will store it in a new Secret
     # you can also specify the name of an existing Secret
-    # with a key of redis-password set to the password you want
-    # existingSecret: ""
+    # set to the password you want
+    existingSecret: ""
+    existingSecretKey: redis-password
   replica:
     replicaCount: 0
 
@@ -749,8 +750,9 @@ redis:
     auth:
       password: ""
       # you can also specify the name of an existing Secret
-      # with a key of redis-password set to the password you want
+      # set to the password you want
       existingSecret: ""
+      existingSecretKey: redis-password
 
   # Configuration for a separate redis instance only for cache.
   # If enabled, any values not specified will be copied from the base config.
@@ -763,8 +765,9 @@ redis:
     auth:
       password: ""
       # you can also specify the name of an existing Secret
-      # with a key of redis-password set to the password you want
+      # set to the password you want
       existingSecret: ""
+      existingSecretKey: redis-password
 
   # -- Node(s) on which we will deploy the various redis pods
   master:


### PR DESCRIPTION
Allows users to set the existing secret key for redis instances. Default values are still set in such a way that the chart will behave the same as before by default.

This change makes it easier for me personally to set up some new infrastructure in a way that's better conforms to standards.