### PR TITLE
Make a secret, mastodon-env, to accept numeric OIDC_CLIENT_ID

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -162,7 +162,7 @@ data:
   OIDC_DISCOVERY: {{ .Values.externalAuth.oidc.discovery | quote }}
   OIDC_SCOPE: {{ .Values.externalAuth.oidc.scope | quote }}
   OIDC_UID_FIELD: {{ .Values.externalAuth.oidc.uid_field }}
-  OIDC_CLIENT_ID: {{ .Values.externalAuth.oidc.client_id }}
+  OIDC_CLIENT_ID: {{ .Values.externalAuth.oidc.client_id | quote }}
   OIDC_CLIENT_SECRET: {{ .Values.externalAuth.oidc.client_secret }}
   OIDC_REDIRECT_URI: {{ .Values.externalAuth.oidc.redirect_uri }}
   OIDC_SECURITY_ASSUME_EMAIL_IS_VERIFIED: {{ .Values.externalAuth.oidc.assume_email_is_verified | quote }}


### PR DESCRIPTION
While I am installing a mastodon instance into may cluster using Zitadel OIDC server, I have met a trouble came from OIDC_CLIENT_ID.
The OIDC_CLIENT_ID of Zitade is a sequence of numbers, then the current template interpret the value is numeric and causes error.
This patch quotes the OIDC_CLIENT_ID to avoid it.

Thank you for reading.
