### PR TITLE
Add a configuration for elasticsearch CA

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -37,6 +37,9 @@ data:
   ES_PRESET: {{ .Values.elasticsearch.preset | default "single_node_cluster" | quote }}
   ES_HOST: {{ include "mastodon.elasticsearch.fullHostname" .}}
   ES_PORT: {{ .Values.elasticsearch.port | default "9200" | quote }}
+  {{- if .Values.elasticsearch.caSecret }}
+  ES_CA_FILE: /opt/opensearch/config/ca.certs
+  {{- end }}
   {{- end }}
   {{- with .Values.elasticsearch.user }}
   ES_USER: {{ . }}

--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -88,6 +88,11 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "mastodon.pvc.system" $context }}
       {{- end }}
+      {{- if $context.Values.elasticsearch.caSecret.name }}
+        - name: elasticsearch-ca
+          secret:
+            secretName: {{ $context.Values.elasticsearch.caSecret.name }}
+      {{- end }}
       {{- include "mastodon.statsdExporterVolume" $ | indent 8 }}
       {{- if dig "customDatabaseConfigYml" "configMapRef" "name" false . }}
         - name: config-database-yml
@@ -234,6 +239,12 @@ spec:
               mountPath: /opt/mastodon/public/assets
             - name: system
               mountPath: /opt/mastodon/public/system
+          {{- end }}
+          {{- if $context.Values.elasticsearch.caSecret.name }}
+            - name: elasticsearch-ca
+              mountPath: /opt/opensearch/config/ca.certs
+              subPath: {{ $context.Values.elasticsearch.caSecret.key }}
+              readOnly: true
           {{- end }}
           {{- if dig "customDatabaseConfigYml" "configMapRef" "name" false . }}
             - name: config-database-yml

--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -69,6 +69,11 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "mastodon.pvc.system" . }}
       {{- end }}
+      {{- if .Values.elasticsearch.caSecret.name }}
+        - name: elasticsearch-ca
+          secret:
+            secretName: {{ .Values.elasticsearch.caSecret.name}}
+      {{- end }}
       {{- include "mastodon.statsdExporterVolume" $ | indent 8 }}
       {{- if .Values.mastodon.web.customDatabaseConfigYml.configMapRef.name }}
         - name: config-database-yml
@@ -219,6 +224,12 @@ spec:
               mountPath: /opt/mastodon/public/assets
             - name: system
               mountPath: /opt/mastodon/public/system
+          {{- end }}
+          {{- if .Values.elasticsearch.caSecret.name }}
+            - name: elasticsearch-ca
+              mountPath: /opt/opensearch/config/ca.certs
+              subPath: {{ .Values.elasticsearch.caSecret.key }}
+              readOnly: true
           {{- end }}
           {{- if .Values.mastodon.web.customDatabaseConfigYml.configMapRef.name }}
             - name: config-database-yml

--- a/values.yaml
+++ b/values.yaml
@@ -586,6 +586,12 @@ elasticsearch:
   # Name of an existing secret with a password key
   # existingSecret:
 
+  caSecret:
+    # caSecret.name is the name of the secret containing the CA certificate.
+    name:
+    # caSecret.key is the key in the secret containing the CA certificate.
+    key: ca.crt
+
 # Configuration for PostgreSQL.
 # When enabled, the bitnami helm chart is used for PostgreSQL deployment, and
 # all values here correspond to their values file. Please see the bitnami chart


### PR DESCRIPTION
While I am installing a mastodon instance into may cluster using opensearch cluster with self signed certs, I have met a trouble came from the cert CA.
This patch adds [ES_CA_FILE environment value](https://docs.joinmastodon.org/admin/config/#es_ca_file) into the mastodn-env configmap and solve this problem.

Thank you for reading.