### PR TITLE
Add a configuration value, [ES_PREFIX](https://docs.joinmastodon.org/admin/config/#es_prefix)

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -41,6 +41,9 @@ data:
   {{- with .Values.elasticsearch.user }}
   ES_USER: {{ . }}
   {{- end }}
+  {{- if .Values.elasticsearch.indexPrefix }}
+  ES_PREFIX: {{ .Values.elasticsearch.indexPrefix | quote }}
+  {{- end }}
   LOCAL_DOMAIN: {{ .Values.mastodon.local_domain }}
   {{- with .Values.mastodon.web_domain }}
   WEB_DOMAIN: {{ . }}

--- a/values.yaml
+++ b/values.yaml
@@ -586,6 +586,9 @@ elasticsearch:
   # Name of an existing secret with a password key
   # existingSecret:
 
+  # elasticsearchIndexPrefix specifies the prefix for Elasticsearch indices used by this Mastodon server
+  # indexPrefix: ""
+
 # Configuration for PostgreSQL.
 # When enabled, the bitnami helm chart is used for PostgreSQL deployment, and
 # all values here correspond to their values file. Please see the bitnami chart


### PR DESCRIPTION
While I am installing a mastodon instance into may cluster, I have found this [ES_PREFIX](https://docs.joinmastodon.org/admin/config/#es_prefix) feature useful for the open search cluster that shared with other projects.
Please consider to merge 

Thank you for reading.
