### PR TITLE
S3_PROTOCOL as a variable

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -93,7 +93,7 @@ data:
   S3_ENABLED: "true"
   S3_ENDPOINT: {{ .Values.mastodon.s3.endpoint }}
   S3_HOSTNAME: {{ .Values.mastodon.s3.hostname }}
-  S3_PROTOCOL: "https"
+  S3_PROTOCOL: {{ .Values.mastodon.s3.protocol }}
   {{- if .Values.mastodon.s3.permission }}
   S3_PERMISSION: {{ .Values.mastodon.s3.permission }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -160,6 +160,7 @@ mastodon:
     existingSecret: ""
     bucket: ""
     endpoint: ""
+    protocol: https
     hostname: ""
     region: ""
     permission: ""


### PR DESCRIPTION
While I am installing a mastodon instance into may cluster using rook/ceph object storage, I had to change the [S3_PROTOCOL variable](https://docs.joinmastodon.org/admin/config/#s3_protocol) to use local object storage bucket.
Please consider to merge.

Thank you for reading.
