### PR TITLE
add configuration variables to set log level

### DIFF
--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}
 data:
+  RAILS_LOG_LEVEL: {{ .Values.mastodon.logLevel.rails | default "info" }}
+  LOG_LEVEL: {{ .Values.mastodon.logLevel.streaming | default "info" }}
   DB_HOST: {{ template "mastodon.postgres.host" . }}
   DB_PORT: {{ template "mastodon.postgres.port" . }}
   DB_NAME: {{ .Values.postgresql.auth.database }}

--- a/values.yaml
+++ b/values.yaml
@@ -11,6 +11,12 @@ image:
   pullPolicy: IfNotPresent
 
 mastodon:
+  logLevel:
+    # Set log level for the web and Sidekiq processes.
+    rails: info
+    # Set log level for the streaming process.
+    streaming: info
+
   # Labels added to every Mastodon-related object
   labels: {}
   # Labes added to every deployed mastodon pod


### PR DESCRIPTION
I've added the following configuration variables to set log levels:

- [RAILS_LOG_LEVEL](https://docs.joinmastodon.org/admin/config/#rails_log_level)
- [LOG_LEVEL](https://docs.joinmastodon.org/admin/config/#log_level)

These variables are usefult when trobuleshooting.
Please consider to merging this PR.

Thank you for reading.