### PR TITLE
keep PVCs after release deletion

### DIFF
--- a/templates/pvc-assets.yaml
+++ b/templates/pvc-assets.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ template "mastodon.fullname" . }}-assets
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}
+  {{- if .Values.mastodon.persistence.assets.keepAfterDelete }}
+  annotations:
+    helm.sh/hook-delete-policy: keep
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.mastodon.persistence.assets.accessMode }}

--- a/templates/pvc-system.yaml
+++ b/templates/pvc-system.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ template "mastodon.fullname" . }}-system
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}
+  {{- if .Values.mastodon.persistence.system.keepAfterDelete }}
+  annotations:
+    helm.sh/hook-delete-policy: keep
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.mastodon.persistence.system.accessMode }}

--- a/values.yaml
+++ b/values.yaml
@@ -139,6 +139,7 @@ mastodon:
       # scalability, since it requires the Rails and Sidekiq pods to run on the
       # same node.
       accessMode: ReadWriteOnce
+      keepAfterDelete: true
       resources:
         requests:
           storage: 10Gi
@@ -146,6 +147,7 @@ mastodon:
       existingClaim:
     system:
       accessMode: ReadWriteOnce
+      keepAfterDelete: true
       resources:
         requests:
           storage: 100Gi


### PR DESCRIPTION
I've added the helm.sh/hook-delete-policy: keep annotation to the PVC manifests.
This change may help prevent data loss for careless admins like me.

Please consider merging this PR.
Thank you for your time.