### PR TITLE
Add support for OIDC client secret from existing secret

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -188,6 +188,17 @@ Get the mastodon secret.
 {{- end -}}
 {{- end -}}
 
+    {{/*
+    Get the oidc secret.
+    */}}
+    {{- define "externalAuth.secretName" -}}
+    {{- if .Values.externalAuth.oidc.existingSecret }}
+        {{- printf "%s" (tpl .Values.externalAuth.oidc.existingSecret $) -}}
+    {{- else -}}
+        {{- printf "%s-oidc" (include "mastodon.fullname" .) -}}
+    {{- end -}}
+    {{- end -}}
+
 {{/*
 Get the smtp secrets.
 */}}

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -204,9 +204,11 @@ data:
   OIDC_SCOPE: {{ .Values.externalAuth.oidc.scope | quote }}
   OIDC_UID_FIELD: {{ .Values.externalAuth.oidc.uid_field }}
   OIDC_CLIENT_ID: {{ .Values.externalAuth.oidc.client_id | quote }}
-  OIDC_CLIENT_SECRET: {{ .Values.externalAuth.oidc.client_secret }}
   OIDC_REDIRECT_URI: {{ .Values.externalAuth.oidc.redirect_uri }}
   OIDC_SECURITY_ASSUME_EMAIL_IS_VERIFIED: {{ .Values.externalAuth.oidc.assume_email_is_verified | quote }}
+  {{- if and .Values.externalAuth.oidc.client_secret (not .Values.externalAuth.oidc.existingSecret) }}
+  OIDC_CLIENT_SECRET: {{ .Values.externalAuth.oidc.client_secret | quote }}
+  {{- end }}
   {{- with .Values.externalAuth.oidc.client_auth_method }}
   OIDC_CLIENT_AUTH_METHOD: {{ . }}
   {{- end }}

--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -112,6 +112,20 @@ spec:
                 secretKeyRef:
                   name: {{ template "mastodon.postgresql.secretName" . }}
                   key: password
+            {{- with .Values.externalAuth.oidc }}
+            {{- if .enabled }}
+              {{- if .existingSecret }}
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .existingSecret | quote }}
+                  key: OIDC_CLIENT_SECRET
+              {{- else if .client_secret }}
+            - name: OIDC_CLIENT_SECRET
+              value: {{ .client_secret | quote }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.postgresql.readReplica.auth.existingSecret }}
             - name: "REPLICA_DB_PASS"
               valueFrom:


### PR DESCRIPTION
Introduces logic to use an existing Kubernetes secret for the OIDC client secret if specified, otherwise falls back to the value from values.yaml. Updates helper templates, configmap, and deployment to support this conditional handling.

Basically, you now can use existinSecret for the OIDC configuration or use the old way.