### PR TITLE
Remove duplicated `replica` key in Redis configuration

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -795,8 +795,6 @@ redis:
     # set to the password you want
     existingSecret: ""
     existingSecretKey: redis-password
-  replica:
-    replicaCount: 0
 
   # Configuration for a separate redis instance only for sidekiq processing.
   # If enabled, any values not specified will be copied from the base config.
@@ -833,6 +831,7 @@ redis:
     nodeSelector: {}
   replica:
     nodeSelector: {}
+    replicaCount: 0
 
 # @ignored
 service:


### PR DESCRIPTION
56e36d266cfce9cfc3c5f2983e013f9f880a973f added a duplicated `replica` key in Redis configuration. This PR simply merge the two together.