### PR TITLE
Bump chart and app versions to 6.9.0 and v4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.9.0
+
+- Update the mastodon version to v4.6.0. Please refer to the [release notes](https://github.com/mastodon/mastodon/releases/tag/v4.6.0) for important changes.
+
 # 6.8.7
 
 - Update the mastodon version to v4.5.11

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.8.7
+version: 6.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "v4.5.11"
+appVersion: "v4.6.0"
 
 dependencies:
   - name: elasticsearch


### PR DESCRIPTION
Update the helm chart to the newely release mastodon version 