### PR TITLE
Update README for chart deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,11 @@ Kubernetes cluster.  The basic usage is:
 
 This chart is tested with k8s 1.21+ and helm 3.8.0+.
 
-# NOTICE: Future Deprecation
+# ⚠️ NOTICE ⚠️: This chart is deprecated
 
-We have plans in the very near future to deprecate this chart in favor of a [new git repo](https://github.com/mastodon/helm-charts), which has proper helm repository support (e.g. `helm repo add`), and will contain multiple charts, both for mastodon and for supplementary components that we make use of.
+As of the release of Mastodon v4.6.0, this chart is now deprecated, and will no longer receive new features. It will continue to be updated with new Mastodon releases for a time.
 
-We still encourage suggestions and PRs to help make this chart better, and this repository will remain available after the new charts are ready to give users time to migrate. However, we will not be approving large PRs, or PRs that change fundamental chart functions, as those changes should be directed to the new charts.
-
-Please see the pinned [GitHub issue](https://github.com/mastodon/chart/issues/129) for more info & discussion.
+We encourage everyone to use our [new helm chart](https://github.com/mastodon/helm-charts/tree/main/charts/mastodon) going forward. Please refer to the [Migration Guide](https://github.com/mastodon/helm-charts/blob/main/charts/mastodon/MIGRATION.md) for instructions on how to begin using the new chart.
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This chart is tested with k8s 1.21+ and helm 3.8.0+.
 
 # ⚠️ NOTICE ⚠️: This chart is deprecated
 
-As of the release of Mastodon v4.6.0, this chart is now deprecated, and will no longer receive new features. It will continue to be updated with new Mastodon releases for a time.
+As of the release of Mastodon v4.6.0, this chart is now deprecated, and will no longer receive new features. It will continue to be updated with new Mastodon releases until 2026-12-31.
 
 We encourage everyone to use our [new helm chart](https://github.com/mastodon/helm-charts/tree/main/charts/mastodon) going forward. Please refer to the [Migration Guide](https://github.com/mastodon/helm-charts/blob/main/charts/mastodon/MIGRATION.md) for instructions on how to begin using the new chart.
 


### PR DESCRIPTION
Updated the README to notify of official deprecation in favor of the new chart.

@renchap I wanted to add a more specific limit for how long we want to continue to update the mastodon version numbers in this chart. Shall we say until v4.8?